### PR TITLE
Fix compilation in c89 mode

### DIFF
--- a/src/run.c
+++ b/src/run.c
@@ -70,6 +70,7 @@ static void run(uint8_t *out, char *pwd, uint8_t *salt, uint32_t t_cost,
     clock_t start_time, stop_time;
     unsigned pwd_length;
     argon2_context context;
+    int i;
 
     start_time = clock();
 
@@ -126,7 +127,7 @@ static void run(uint8_t *out, char *pwd, uint8_t *salt, uint32_t t_cost,
     printf("%s\n", encoded);
     */
     printf("Hash:\t\t");
-    for(int i=0; i<context.outlen; ++i) {
+    for(i=0; i<context.outlen; ++i) {
         printf("%02x", context.out[i]);
     }
     printf("\n");


### PR DESCRIPTION
The package is explicitly compiled in c89 compatiblity mode, but uses a declaration that requires c99 (which breaks at least on OpenBSD)