### PR TITLE
Include unistd.h in src/run.c

### DIFF
--- a/src/run.c
+++ b/src/run.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "argon2.h"
 #include "core.h"


### PR DESCRIPTION
This fix a compilation error on my linux box (missing ssize_t)