### PR TITLE
Fails to build - variable names.

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -215,7 +215,7 @@ int argon2d_hash_raw(const uint32_t t_cost, const uint32_t m_cost,
                        hash, hashlen, NULL, 0, Argon2_d);
 }
 
-int argon2_compare(const char *b1_, const char *b2_, size_t len) {
+int argon2_compare(const char *b1, const char *b2, size_t len) {
     size_t               i;
     unsigned char        d = (unsigned char) 0U;
 


### PR DESCRIPTION
Build fails with:

    src/argon2.c:223:22: error: 'b2' undeclared (first use in this function)
         d |= b1[i] ^ b2[i];

Addresses variable names to fix.
