### PR TITLE
Paranoid return checks on malloc.

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -130,6 +130,9 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
     }
 
     out = malloc(hashlen);
+    if (!out) {
+        return ARGON2_MEMORY_ALLOCATION_ERROR;
+    }
 
     context.out = (uint8_t *)out;
     context.outlen = (uint32_t)hashlen;
@@ -239,7 +242,13 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     ctx.ad = malloc(ctx.adlen);
     ctx.salt = malloc(ctx.saltlen);
     ctx.out = malloc(ctx.outlen);
+    if (!ctx.out || !ctx.salt || !ctx.ad) {
+        return ARGON2_MEMORY_ALLOCATION_ERROR;
+    }
     out = malloc(ctx.outlen);
+    if (!out) {
+        return ARGON2_MEMORY_ALLOCATION_ERROR;
+    }
 
     decode_string(&ctx, encoded, type);
 

--- a/src/argon2.c
+++ b/src/argon2.c
@@ -243,10 +243,16 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     ctx.salt = malloc(ctx.saltlen);
     ctx.out = malloc(ctx.outlen);
     if (!ctx.out || !ctx.salt || !ctx.ad) {
+        free(ctx.ad);
+        free(ctx.salt);
+        free(ctx.out);
         return ARGON2_MEMORY_ALLOCATION_ERROR;
     }
     out = malloc(ctx.outlen);
     if (!out) {
+        free(ctx.ad);
+        free(ctx.salt);
+        free(ctx.out);
         return ARGON2_MEMORY_ALLOCATION_ERROR;
     }
 


### PR DESCRIPTION
I appreciate some of these values are quite small and unlikely to fail, however:

* Some of these values are caller defined and could be as large as the caller provides
* Better safe than sorry
* This makes it consistent with other malloc calls