### PR TITLE
Removing hijack of $CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ GENKAT = genkat
 
 DIST = phc-winner-argon2
 
-CC = gcc
 SRC = src/argon2.c src/core.c src/blake2/blake2b.c src/thread.c src/encoding.c
 SRC_RUN = src/run.c
 SRC_BENCH = src/bench.c


### PR DESCRIPTION
This fix means people don't have to modify the Makefile in order to use other compilers.