### PR TITLE
Don't dereference a pointer before checking that it's not NULL

### DIFF
--- a/src/opt.c
+++ b/src/opt.c
@@ -91,7 +91,7 @@ void fill_segment(const argon2_instance_t *instance,
     uint32_t prev_offset, curr_offset;
     uint32_t starting_index, i;
     __m128i state[64];
-    int data_independent_addressing = (instance->type == Argon2_i);
+    int data_independent_addressing;
 
     /* Pseudo-random values that determine the reference block position */
     uint64_t *pseudo_rands = NULL;
@@ -99,6 +99,8 @@ void fill_segment(const argon2_instance_t *instance,
     if (instance == NULL) {
         return;
     }
+
+    data_independent_addressing = (instance->type == Argon2_i);
 
     pseudo_rands =
         (uint64_t *)malloc(sizeof(uint64_t) * instance->segment_length);

--- a/src/ref.c
+++ b/src/ref.c
@@ -97,13 +97,15 @@ void fill_segment(const argon2_instance_t *instance,
     uint32_t prev_offset, curr_offset;
     uint32_t starting_index;
     uint32_t i;
-    int data_independent_addressing = (instance->type == Argon2_i);
+    int data_independent_addressing;
     /* Pseudo-random values that determine the reference block position */
     uint64_t *pseudo_rands = NULL;
 
     if (instance == NULL) {
         return;
     }
+
+    data_independent_addressing = (instance->type == Argon2_i);
 
     pseudo_rands =
         (uint64_t *)malloc(sizeof(uint64_t) * (instance->segment_length));


### PR DESCRIPTION
Harmless here, but it doesn't hurt since `fill_segment()` is supposed to be a no-op with a NULL instance.