### PR TITLE
Memory usage is m_cost KiB, not 2^m_cost KiB

### DIFF
--- a/src/argon2.h
+++ b/src/argon2.h
@@ -205,7 +205,7 @@ int argon2_core(argon2_context *context, argon2_type type);
 /**
  * Hashes a password with Argon2i, producing an encoded hash
  * @param t_cost Number of iterations
- * @param m_cost Sets memory usage to 2^m_cost kibibytes
+ * @param m_cost Sets memory usage to m_cost kibibytes
  * @param parallelism Number of threads and compute lanes
  * @param pwd Pointer to password
  * @param pwdlen Password size in bytes
@@ -226,7 +226,7 @@ int argon2i_hash_encoded(const uint32_t t_cost, const uint32_t m_cost,
 /**
  * Hashes a password with Argon2i, producing a raw hash
  * @param t_cost Number of iterations
- * @param m_cost Sets memory usage to 2^m_cost kibibytes
+ * @param m_cost Sets memory usage to m_cost kibibytes
  * @param parallelism Number of threads and compute lanes
  * @param pwd Pointer to password
  * @param pwdlen Password size in bytes


### PR DESCRIPTION
Harmless here, but it doesn't hurt since `fill_segment()` is supposed to be a no-op with a NULL instance.