### PR TITLE
argon2: add negative index check to error_message

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -391,7 +391,7 @@ const char *error_message(int error_code) {
             !!((sizeof(Argon2_ErrorMessage) / sizeof(Argon2_ErrorMessage[0])) ==
                ARGON2_ERROR_CODES_LENGTH)
     };
-    if (error_code < ARGON2_ERROR_CODES_LENGTH) {
+    if (error_code >= 0 && error_code < ARGON2_ERROR_CODES_LENGTH) {
         return Argon2_ErrorMessage[(argon2_error_codes)error_code];
     }
     return "Unknown error code.";


### PR DESCRIPTION
This adds a check for negative index values, preventing an index
out-of-bounds access. Closes #66

Signed-off-by: Luca Bruno <lucab@debian.org>