### PR TITLE
Fix/workaround some gcc  extra warnings

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -11,11 +11,9 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <limits.h>
 
 #include "argon2.h"
 #include "encoding.h"
@@ -273,7 +271,7 @@ int argon2d_hash_raw(const uint32_t t_cost, const uint32_t m_cost,
                        hash, hashlen, NULL, 0, Argon2_d);
 }
 
-int argon2_compare(const uint8_t *b1, const uint8_t *b2, size_t len) {
+static int argon2_compare(const uint8_t *b1, const uint8_t *b2, size_t len) {
     size_t i;
     uint8_t d = 0U;
 

--- a/src/argon2.c
+++ b/src/argon2.c
@@ -191,9 +191,9 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
 
     context.out = (uint8_t *)out;
     context.outlen = (uint32_t)hashlen;
-    context.pwd = (uint8_t *)pwd;
+    context.pwd = CONST_CAST(uint8_t *)pwd;
     context.pwdlen = (uint32_t)pwdlen;
-    context.salt = (uint8_t *)salt;
+    context.salt = CONST_CAST(uint8_t *)salt;
     context.saltlen = (uint32_t)saltlen;
     context.secret = NULL;
     context.secretlen = 0;

--- a/src/core.h
+++ b/src/core.h
@@ -24,6 +24,8 @@
 #define ALIGN(x)
 #endif
 
+#define CONST_CAST(x) (x)(uintptr_t)
+
 /*************************Argon2 internal
  * constants**************************************************/
 

--- a/src/opt.c
+++ b/src/opt.c
@@ -16,7 +16,6 @@
 #include <stdlib.h>
 
 #include "argon2.h"
-#include "core.h"
 #include "opt.h"
 
 #include "blake2/blake2.h"

--- a/src/opt.h
+++ b/src/opt.h
@@ -14,10 +14,8 @@
 #ifndef ARGON2_OPT_H
 #define ARGON2_OPT_H
 
-#include <stdint.h>
-#include <emmintrin.h>
-#include "argon2.h"
 #include "core.h"
+#include <emmintrin.h>
 
 /*
  * Function fills a new memory block. Differs from the
@@ -39,16 +37,5 @@ void fill_block(__m128i *state, const uint8_t *ref_block, uint8_t *next_block);
 void generate_addresses(const argon2_instance_t *instance,
                         const argon2_position_t *position,
                         uint64_t *pseudo_rands);
-
-/*
- * Function that fills the segment using previous segments also from other
- * threads.
- * Identical to the reference code except that it calls optimized FillBlock()
- * @param instance Pointer to the current instance
- * @param position Current position
- * @pre all block pointers must be valid
- */
-void fill_segment(const argon2_instance_t *instance,
-                  argon2_position_t position);
 
 #endif /* ARGON2_OPT_H */

--- a/src/ref.c
+++ b/src/ref.c
@@ -16,7 +16,6 @@
 #include <stdlib.h>
 
 #include "argon2.h"
-#include "core.h"
 #include "ref.h"
 
 #include "blake2/blamka-round-ref.h"

--- a/src/ref.h
+++ b/src/ref.h
@@ -14,6 +14,8 @@
 #ifndef ARGON2_REF_H
 #define ARGON2_REF_H
 
+#include "core.h"
+
 /*
  * Function fills a new memory block
  * @param prev_block Pointer to the previous block
@@ -35,15 +37,5 @@ void fill_block(const block *prev_block, const block *ref_block,
 void generate_addresses(const argon2_instance_t *instance,
                         const argon2_position_t *position,
                         uint64_t *pseudo_rands);
-
-/*
- * Function that fills the segment using previous segments also from other
- * threads
- * @param instance Pointer to the current instance
- * @param position Current position
- * @pre all block pointers must be valid
- */
-void fill_segment(const argon2_instance_t *instance,
-                  argon2_position_t position);
 
 #endif /* ARGON2_REF_H */


### PR DESCRIPTION
If you add some more gcc checks, like mentioned below, a lot of warnings appears.

Some are fixed with patches, some like
  ``comparison of unsigned expression < 0 is always false``
  ``comparison is always false due to limited range of data type``
are in range check code and depends on exact #defines...
(Anyway, in the current setting it is dead code because
checks are equal to uin32_t data type on input...)

I would prefer that code should avoid these warning because later
some real problem could appear and it is easy to overlook a new warning.

Tested with Makefile with these added options:
```
CFLAGS += -Wextra \
 -Wsign-compare \
 -Werror-implicit-function-declaration \
 -Wpointer-arith \
 -Wwrite-strings \
 -Wswitch \
 -Wmissing-format-attribute \
 -Wstrict-aliasing=3 \
 -Winit-self \
 -Wunsafe-loop-optimizations \
 -Wdeclaration-after-statement \
 -Wold-style-definition \
 -Wno-missing-field-initializers \
 -Wno-unused-parameter \
 -Wno-attributes \
 -Wno-long-long \
 -Wall -Wuninitialized \
 -Wno-switch \
 -Wdisabled-optimization \
 -Wwrite-strings \
 -Wpointer-arith \
 -Wbad-function-cast \
 -Wmissing-prototypes \
 -Wmissing-declarations \
 -Wstrict-prototypes \
 -Wnested-externs \
 -Wcomment \
 -Winline \
 -Wcast-align \
 -Wcast-qual \
 -Wredundant-decls
```