### PR TITLE
Introduces an error state for threading failures. Fixes #64.

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -102,7 +102,9 @@ static const char *Argon2_ErrorMessage[] = {
     /*},
 {ARGON2_ENCODING_FAIL, */ "Encoding failed",
     /*},
-{ARGON2_DECODING_FAIL, */ "Decoding failed", /*},*/
+{ARGON2_DECODING_FAIL, */ "Decoding failed",
+    /*},
+{ARGON2_THREAD_FAIL */ "Threading failure", /*},*/
 };
 
 
@@ -151,8 +153,11 @@ int argon2_core(argon2_context *context, argon2_type type) {
     }
 
     /* 4. Filling memory */
-    fill_memory_blocks(&instance);
+    result = fill_memory_blocks(&instance);
 
+    if (ARGON2_OK != result) {
+        return result;
+    }
     /* 5. Finalization */
     finalize(context, &instance);
 

--- a/src/argon2.h
+++ b/src/argon2.h
@@ -129,6 +129,8 @@ typedef enum Argon2_ErrorCodes {
 
     ARGON2_DECODING_FAIL = 32,
 
+    ARGON2_THREAD_FAIL = 33,
+
     ARGON2_ERROR_CODES_LENGTH /* Do NOT remove; Do NOT add error codes after
                                  this
                                  error code */

--- a/src/core.h
+++ b/src/core.h
@@ -212,7 +212,8 @@ void fill_segment(const argon2_instance_t *instance,
  * Function that fills the entire memory t_cost times based on the first two
  * blocks in each lane
  * @param instance Pointer to the current instance
+ * @return ARGON2_OK if successful, @context->state
  */
-void fill_memory_blocks(argon2_instance_t *instance);
+int fill_memory_blocks(argon2_instance_t *instance);
 
 #endif


### PR DESCRIPTION
fill_memory_blocks() configured to return a status, this introduces checks
for a number of a different error conditions, inlcuding calloc() and NULL
pointer failures. These were previously ignored errors.
Thread failures no longer call printf/exit, ensuring better support for
higher level bindings. fill_memory_blocks() is only called in one place,
it's return value is now checked.

Implications for bindings: new error code may need dedicated handling.

This patch can be tested by setting ulimit -u and running ./argon2 with a
relevant thread count.