### PR TITLE
Implement verify fix from libsodium

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -297,6 +297,8 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     ctx.adlen = 512;
     ctx.saltlen = 512;
     ctx.outlen = 512;
+    ctx.allocate_cbk = NULL;
+    ctx.free_cbk = NULL;
 
     ctx.ad = malloc(ctx.adlen);
     ctx.salt = malloc(ctx.saltlen);

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <limits.h>
 #include "encoding.h"
+#include "core.h"
 
 /*
  * Example code for a decoder and encoder of "hash strings", with Argon2i
@@ -292,6 +293,8 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
     ctx->adlen = 0;
     ctx->saltlen = 0;
     ctx->outlen = 0;
+    ctx->pwdlen = 0;
+
     if (type == Argon2_i)
         CC("$argon2i");
     else if (type == Argon2_d)
@@ -306,46 +309,18 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
     DECIMAL(ctx->lanes);
     ctx->threads = ctx->lanes;
 
-    /*
-     * Both m and t must be no more than 2^32-1. The tests below
-     * use a shift by 30 bits to avoid a direct comparison with
-     * 0xFFFFFFFF, which may trigger a spurious compiler warning
-     * on machines where 'unsigned long' is a 32-bit type.
-     */
-    if (ctx->m_cost < 1 || (ctx->m_cost >> 30) > 3) {
-        return 0;
-    }
-    if (ctx->t_cost < 1 || (ctx->t_cost >> 30) > 3) {
-        return 0;
-    }
-
-    /*
-     * The parallelism p must be between 1 and 255. The memory cost
-     * parameter, expressed in kilobytes, must be at least 8 times
-     * the value of p.
-     */
-    if (ctx->lanes < 1 || ctx->lanes > 255) {
-        return 0;
-    }
-    if (ctx->m_cost < (ctx->lanes << 3)) {
-        return 0;
-    }
-
     CC_opt(",data=", BIN(ctx->ad, maxadlen, ctx->adlen));
     if (*str == 0) {
         return 1;
     }
     CC("$");
     BIN(ctx->salt, maxsaltlen, ctx->saltlen);
-    if (ctx->saltlen < 8) {
-        return 0;
-    }
     if (*str == 0) {
         return 1;
     }
     CC("$");
     BIN(ctx->out, maxoutlen, ctx->outlen);
-    if (ctx->outlen < 12) {
+    if (validate_inputs(ctx) != ARGON2_OK) {
         return 0;
     }
     return *str == 0;
@@ -404,6 +379,10 @@ int encode_string(char *dst, size_t dst_len, argon2_context *ctx,
         SS("$argon2d$m=");
     else
         return 0;
+
+    if (validate_inputs(ctx) != ARGON2_OK) {
+        return 0;
+    }
     SX(ctx->m_cost);
     SS(",t=");
     SX(ctx->t_cost);

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -4,7 +4,7 @@
 #include <limits.h>
 #include "encoding.h"
 
-#/*
+/*
  * Example code for a decoder and encoder of "hash strings", with Argon2i
  * parameters.
  *


### PR DESCRIPTION
Fixes #77 , and potentially several related issues stemming from inconsistent verifiers. Original patch from Libsodium.

The original patch would cause verifies, and called in run.c, to fail with ARGON2_PWD_PTR_MISMATCH, and then ARGON2_FREE_MEMORY_CBK_NULL - have introduced extra zeroing to correct this.