### PR TITLE
Utilise existing constants more consistently.

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -175,15 +175,15 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
 
     /* Detect and reject overflowing sizes */
     /* TODO: This should probably be fixed in the function signature */
-    if (pwdlen > UINT32_MAX) {
+    if (pwdlen > ARGON2_MAX_PWD_LENGTH) {
         return ARGON2_PWD_TOO_LONG;
     }
 
-    if (hashlen > UINT32_MAX) {
+    if (hashlen > ARGON2_MAX_OUTLEN) {
         return ARGON2_OUTPUT_TOO_LONG;
     }
 
-    if (saltlen > UINT32_MAX) {
+    if (saltlen > ARGON2_MAX_SALT_LENGTH) {
         return ARGON2_SALT_TOO_LONG;
     }
 


### PR DESCRIPTION
No functional changes - but better use of existing constants reduces risk of future bugs and reads better.