### PR TITLE
Safer handling of initial string sizes.

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -292,11 +292,15 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     argon2_context ctx;
     uint8_t *out;
     int ret;
+    size_t encoded_len;
 
-    /* max values, to be updated in decode_string */
-    ctx.adlen = 512;
-    ctx.saltlen = 512;
-    ctx.outlen = 512;
+    encoded_len = strlen(encoded);
+    /* This is larger than the largest possible size, and thus, safe for 
+     * initialising values. They will be updated in decode_string
+     */
+    ctx.adlen = encoded_len;
+    ctx.saltlen = encoded_len;
+    ctx.outlen = encoded_len;
 
     ctx.ad = malloc(ctx.adlen);
     ctx.salt = malloc(ctx.saltlen);


### PR DESCRIPTION
This removes the ability to create some hashes that cannot be verified correctly. Addresses many of the issues raised in #55. Note in normal cases, this will reduce allocated memory.