### PR TITLE
Fix bench and genkat after low-level API renaming

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -80,9 +80,9 @@ static void benchmark() {
             context.free_cbk = NULL;
             context.flags = 0;
 
-            argon2d(&context);
+            argon2d_ctx(&context);
             stop_cycles = rdtsc();
-            argon2i(&context);
+            argon2i_ctx(&context);
             stop_cycles_i = rdtsc();
             stop_time = clock();
 

--- a/src/genkat.c
+++ b/src/genkat.c
@@ -180,9 +180,9 @@ static void generate_testvectors(const char *type) {
 #undef TEST_ADLEN
 
     if (!strcmp(type, "d")) {
-        argon2d(&context);
+        argon2d_ctx(&context);
     } else if (!strcmp(type, "i")) {
-        argon2i(&context);
+        argon2i_ctx(&context);
     } else
         fatal("wrong Argon2 type");
 }


### PR DESCRIPTION
This fixes build errors in `make bench` and `make test` after low-level API refactoring in d9b0bafe37dbb94f22748b7bc73268b073e4934c.