### PR TITLE
Specialize G^2, eliminate unnecessary memsets/copies, earn a few extra cycles

### DIFF
--- a/src/opt.c
+++ b/src/opt.c
@@ -48,13 +48,37 @@ void fill_block(__m128i *state, const uint8_t *ref_block, uint8_t *next_block) {
     }
 }
 
+void fill_block_lhs_zero(__m128i *state, const uint8_t *ref_block) {
+    __m128i block_XY[ARGON2_OWORDS_IN_BLOCK];
+    uint32_t i;
+
+    for (i = 0; i < ARGON2_OWORDS_IN_BLOCK; i++) {
+        block_XY[i] = state[i] = _mm_loadu_si128((__m128i const *)(&ref_block[16 * i]));
+    }
+
+    for (i = 0; i < 8; ++i) {
+        BLAKE2_ROUND(state[8 * i + 0], state[8 * i + 1], state[8 * i + 2],
+                     state[8 * i + 3], state[8 * i + 4], state[8 * i + 5],
+                     state[8 * i + 6], state[8 * i + 7]);
+    }
+
+    for (i = 0; i < 8; ++i) {
+        BLAKE2_ROUND(state[8 * 0 + i], state[8 * 1 + i], state[8 * 2 + i],
+                     state[8 * 3 + i], state[8 * 4 + i], state[8 * 5 + i],
+                     state[8 * 6 + i], state[8 * 7 + i]);
+    }
+
+    for (i = 0; i < ARGON2_OWORDS_IN_BLOCK; i++) {
+        state[i] = _mm_xor_si128(state[i], block_XY[i]);
+    }
+}
+
 void generate_addresses(const argon2_instance_t *instance,
                         const argon2_position_t *position,
                         uint64_t *pseudo_rands) {
     block address_block, input_block;
     uint32_t i;
 
-    init_block_value(&address_block, 0);
     init_block_value(&input_block, 0);
 
     if (instance != NULL && position != NULL) {
@@ -67,15 +91,10 @@ void generate_addresses(const argon2_instance_t *instance,
 
         for (i = 0; i < instance->segment_length; ++i) {
             if (i % ARGON2_ADDRESSES_IN_BLOCK == 0) {
-                __m128i zero_block[ARGON2_OWORDS_IN_BLOCK];
-                __m128i zero2_block[ARGON2_OWORDS_IN_BLOCK];
-                memset(zero_block, 0, sizeof(zero_block));
-                memset(zero2_block, 0, sizeof(zero2_block));
                 input_block.v[6]++;
-                fill_block(zero_block, (uint8_t *)&input_block.v,
-                           (uint8_t *)&address_block.v);
-                fill_block(zero2_block, (uint8_t *)&address_block.v,
-                           (uint8_t *)&address_block.v);
+
+                fill_block_lhs_zero((__m128i*) &address_block.v, (const uint8_t *) &input_block.v);
+                fill_block_lhs_zero((__m128i*) &address_block.v, (const uint8_t *) &address_block.v);
             }
 
             pseudo_rands[i] = address_block.v[i % ARGON2_ADDRESSES_IN_BLOCK];

--- a/src/opt.c
+++ b/src/opt.c
@@ -93,8 +93,10 @@ void generate_addresses(const argon2_instance_t *instance,
             if (i % ARGON2_ADDRESSES_IN_BLOCK == 0) {
                 input_block.v[6]++;
 
-                fill_block_lhs_zero((__m128i*) &address_block.v, (const uint8_t *) &input_block.v);
-                fill_block_lhs_zero((__m128i*) &address_block.v, (const uint8_t *) &address_block.v);
+                fill_block_lhs_zero((__m128i*) &address_block.v,
+                                    (const uint8_t *) &input_block.v);
+                fill_block_lhs_zero((__m128i*) &address_block.v,
+                                    (const uint8_t *) &address_block.v);
             }
 
             pseudo_rands[i] = address_block.v[i % ARGON2_ADDRESSES_IN_BLOCK];


### PR DESCRIPTION
when generating pseudorandoms for data-independent indexing, the compression function `G`:
```haskell
G x y = p_cols (p_rows (x `xor` y)) `xor` (x `xor` y)
```
is only ever called with `x = 0`, thus reducing it to:
```haskell
G' y = G 0 y = p_cols (p_rows y) `xor` y
```
which means that the extra zero blocks can be ignored to get the same result.

this patch does just that and shaves a few cycles in the benchmarks:
```bash
13:11:47 ~/3rd/phc-winner-argon2> git checkout standalone-g2 && make clean && make bench && ./bench 
Argon2d 1 iterations  512 MiB 1 threads:  4.85 cpb 2485.88 Mcycles 
Argon2i 1 iterations  512 MiB 1 threads:  5.02 cpb 2571.76 Mcycles 
1.5351 seconds

Argon2d 1 iterations  512 MiB 2 threads:  2.82 cpb 1443.86 Mcycles 
Argon2i 1 iterations  512 MiB 2 threads:  3.17 cpb 1625.06 Mcycles 
1.6832 seconds

Argon2d 1 iterations  512 MiB 4 threads:  2.51 cpb 1286.44 Mcycles 
Argon2i 1 iterations  512 MiB 4 threads:  2.52 cpb 1292.88 Mcycles 
1.9616 seconds

Argon2d 1 iterations  512 MiB 6 threads:  3.67 cpb 1881.49 Mcycles 
Argon2i 1 iterations  512 MiB 6 threads:  3.05 cpb 1562.46 Mcycles 
1.9768 seconds
```
compared to master:
```bash
13:11:47 ~/3rd/phc-winner-argon2> git checkout master && make clean && make bench && ./bench 
[snip]
Argon2d 1 iterations  512 MiB 1 threads:  5.19 cpb 2656.39 Mcycles 
Argon2i 1 iterations  512 MiB 1 threads:  5.37 cpb 2751.06 Mcycles 
1.6205 seconds

Argon2d 1 iterations  512 MiB 2 threads:  3.91 cpb 1999.67 Mcycles 
Argon2i 1 iterations  512 MiB 2 threads:  2.95 cpb 1512.90 Mcycles 
1.7973 seconds

Argon2d 1 iterations  512 MiB 4 threads:  2.41 cpb 1236.37 Mcycles 
Argon2i 1 iterations  512 MiB 4 threads:  2.77 cpb 1416.20 Mcycles 
1.9347 seconds

Argon2d 1 iterations  512 MiB 6 threads:  3.57 cpb 1825.56 Mcycles 
Argon2i 1 iterations  512 MiB 6 threads:  2.69 cpb 1377.52 Mcycles 
2.0352 seconds
```