### PR TITLE
More C99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,5 +93,7 @@ dist:
 test:
 		@sh kats/test.sh
 
+.PHONY: test
+
 format:
 		clang-format -style="{BasedOnStyle: llvm, IndentWidth: 4}" -i src/*.c src/*.h src/blake2/*.c src/blake2/*.h

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -290,6 +290,7 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
     size_t maxadlen = ctx->adlen;
     size_t maxsaltlen = ctx->saltlen;
     size_t maxoutlen = ctx->outlen;
+    int validation_result;
 
     ctx->adlen = 0;
     ctx->saltlen = 0;
@@ -321,7 +322,7 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
     }
     CC("$");
     BIN(ctx->out, maxoutlen, ctx->outlen);
-    int validation_result = validate_inputs(ctx);
+    validation_result = validate_inputs(ctx);
     if (validation_result != ARGON2_OK) {
         return validation_result;
     }


### PR DESCRIPTION
Also marks test as .PHONY otherwise you'll get:

```
make: `test' is up to date.
```

when running "make test".

***

I wish I could give out them all at once to you but currently I’m bound by running it against my CI: 

- https://ci.appveyor.com/project/hynek/argon2-cffi/build/job/svg9lob397q7v4mu
- https://ci.appveyor.com/project/hynek/argon2-cffi/build/job/akhhjb890qf81u2t