### PR TITLE
Make general test compile flags more relaxed than CI test case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
 compiler:
  - clang
-script: make && make test
+script: make && make testci
 

--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,14 @@ dist:
 		tar -c --exclude='.??*' -z -f $(DIST)-`date "+%Y%m%d"`.tgz $(DIST)/*
 
 test:   $(SRC) src/test.c
-		$(CC) $(CFLAGS)  -Werror=declaration-after-statement -D_FORTIFY_SOURCE=2 -Wextra -Wno-type-limits -Werror -fsanitize=address -fsanitize=undefined $^ -o testcase
+		$(CC) $(CFLAGS)  -Wextra -Wno-type-limits $^ -o testcase
 		@sh kats/test.sh
 		./testcase
 
+testci:   $(SRC) src/test.c
+		$(CC) $(CFLAGS)  -Werror=declaration-after-statement -D_FORTIFY_SOURCE=2 -Wextra -Wno-type-limits -Werror -fsanitize=address -fsanitize=undefined $^ -o testcase
+		@sh kats/test.sh
+		./testcase
 
 .PHONY: test
 


### PR DESCRIPTION
Fixes #101.
Having the most strict configuration in CI ensures build quality, whilst removing less supported flags from general tests ensures portability.
Also removed -Werror from non-CI tests, to prevent total failures due to different compiler's reporting standards.