### PR TITLE
Issue different error codes for verify failure and mismatch

### DIFF
--- a/include/argon2.h
+++ b/include/argon2.h
@@ -140,6 +140,8 @@ typedef enum Argon2_ErrorCodes {
 
     ARGON2_DECODING_LENGTH_FAIL = 34,
 
+    ARGON2_VERIFY_MISMATCH = 35,
+
     ARGON2_ERROR_CODES_LENGTH /* Do NOT remove; Do NOT add error codes after
                                  this
                                  error code */

--- a/src/argon2.c
+++ b/src/argon2.c
@@ -104,7 +104,9 @@ static const char *Argon2_ErrorMessage[] = {
     /*},
 {ARGON2_THREAD_FAIL */ "Threading failure",
     /*,
-{ARGON2_DECODING_LENGTH_FAIL */ "Some of encoded parameters are too long or too short" /*},*/
+{ARGON2_DECODING_LENGTH_FAIL */ "Some of encoded parameters are too long or too short",
+    /*,
+{ARGON2_VERIFY_MISMATCH */ "The password does not match the supplied hash" /*},*/
 };
 
 int argon2_ctx(argon2_context *context, argon2_type type) {
@@ -334,15 +336,13 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     free(ctx.ad);
     free(ctx.salt);
 
-    if (ret != ARGON2_OK || argon2_compare(out, ctx.out, ctx.outlen)) {
-        free(out);
-        free(ctx.out);
-        return ARGON2_DECODING_FAIL;
+    if (ret == ARGON2_OK && argon2_compare(out, ctx.out, ctx.outlen)) {
+        ret = ARGON2_VERIFY_MISMATCH;
     }
     free(out);
     free(ctx.out);
 
-    return ARGON2_OK;
+    return ret;
 }
 
 int argon2i_verify(const char *encoded, const void *pwd, const size_t pwdlen) {

--- a/src/test.c
+++ b/src/test.c
@@ -116,7 +116,15 @@ int main() {
     assert(ret == ARGON2_DECODING_FAIL);
     printf("Recognise an invalid encoding: PASS\n");
 
-    msg = argon2_error_message(ret);
+    /* Handle an mismatching hash (the encoded password is "passwore") */
+    ret = argon2_verify("$argon2i$m=262144,t=2,p=1$"
+                        "c29tZXNhbHQAAAAAAAAAAA$46sIq3FdcR"
+                        "xWU4xcqtfdi2D5+f1GuNpPnpybS38pmDI",
+                        "password", strlen("password"), Argon2_i);
+    assert(ret == ARGON2_VERIFY_MISMATCH);
+    printf("Verify with mismatched password: PASS\n");
+
+    msg = argon2_error_message(ARGON2_DECODING_FAIL);
     assert(strcmp(msg, "Decoding failed")==0);
     printf("Decode an error message: PASS\n");
 


### PR DESCRIPTION
Currently the `argon2_verify` function returns `ARGON2_DECODING_FAIL` for both if there was any error during the hashing (even if it was not a decoding failure) or if the password does not match with the supplied hash.

This commit makes a mismatching hash return `ARGON2_VERIFY_MISMATCH` instead, making it possible to detect if there was a failure or if the password just does not match. Additionally, it forwards the verification hashing error for better diagnostic.

There's also a test for mismatching password verification.