### PR TITLE
Utilise OPT on supported platforms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,13 @@ CFLAGS += -std=c89 -pthread -O3 -Wall -g -Iinclude -Isrc
 CI_CFLAGS := $(CFLAGS) -Werror=declaration-after-statement -D_FORTIFY_SOURCE=2 \
 				-Wextra -Wno-type-limits -Werror -coverage
 
-#OPT=TRUE
-ifeq ($(OPT), TRUE)
+OPTTEST := $(shell $(CC) -Iinclude -Isrc -march=native src/opt.c -c 2>/dev/null; echo $$?)
+# Detect compatible platform
+ifneq ($(OPTTEST), 0)
+	SRC += src/ref.c
+else
 	CFLAGS += -march=native
 	SRC += src/opt.c
-else
-	SRC += src/ref.c
 endif
 
 BUILD_PATH := $(shell pwd)


### PR DESCRIPTION
There are currently a number of issues with the OPT parameter.

- As far as I can see, it's undocumented. I only know about it because I did some work in the Makefile.
- The fact it just refers to "optimisations" and not "x86 specific optimisations" can be confusing
- Releases and distributions are forced to either utilise the flag, and write apps that are x86 specific, or not use the flag, and release suboptimal code.
- This led to #112.
- The majority of bindings have utilised the path of least resistance and not used this flag at all
- This means the majority of deployments are not using the optimised path
- Slower code may lead to reduced work strengths than servers are suited for

This change aims to work around it. The logic looks backwards - but I've tested on EC2 (x86_64) and Raspberry Pi (armv71) and it runs correctly. Maybe a few +1's on different platforms would go down well.