### PR TITLE
Fix cli tool to handle variable length salts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ all: clean $(RUN) libs
 libs: $(LIB_SH) $(LIB_ST)
 
 $(RUN):	        $(SRC) $(SRC_RUN)
-		$(CC) $(CFLAGS) $(LDFLAGS) $^ -lm -o $@
+		$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
 $(BENCH):       $(SRC) $(SRC_BENCH)
 		$(CC) $(CFLAGS) $^ -o $@

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ all: clean $(RUN) libs
 libs: $(LIB_SH) $(LIB_ST)
 
 $(RUN):	        $(SRC) $(SRC_RUN)
-		$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
+		$(CC) $(CFLAGS) $(LDFLAGS) $^ -lm -o $@
 
 $(BENCH):       $(SRC) $(SRC_BENCH)
 		$(CC) $(CFLAGS) $^ -o $@

--- a/README.md
+++ b/README.md
@@ -57,18 +57,20 @@ Parameters:
         -t N            Sets the number of iterations to N (default = 3)
         -m N            Sets the memory usage of 2^N KiB (default 12)
         -p N            Sets parallelism to N threads (default 1)
+        -h N            Sets hash output length to N bytes (default 32)
 ```
 For example, to hash "password" using "somesalt" as a salt and doing 2
-iterations, consuming 64 MiB, and using four parallel threads:
+iterations, consuming 64 MiB, using four parallel threads and an output hash
+of 24 bytes
 ```
-$ echo -n "password" | ./argon2 somesalt -t 2 -m 16 -p 4
+$ echo -n "password" | ./argon2 somesalt -t 2 -m 16 -p 4 -h 24
 Type:           Argon2i
 Iterations:     2
 Memory:         65536 KiB
 Parallelism:    4
-Hash:           4162f32384d8f4790bd994cb73c83a4a29f076165ec18af3cfdcf10a8d1b9066
-Encoded:        $argon2i$m=65536,t=2,p=4$c29tZXNhbHQAAAAAAAAAAA$QWLzI4TY9HkL2ZTLc8g6SinwdhZewYrzz9zxCo0bkGY
-0.271 seconds
+Hash:           5a028f1a99c9eae671ee448ab80057b78510430865abe57f
+Encoded:        $argon2i$m=65536,t=2,p=4$c29tZXNhbHQ$WgKPGpnJ6uZx7kSKuABXt4UQQwhlq+V/
+0.188 seconds
 Verification ok
 ```
 

--- a/src/run.c
+++ b/src/run.c
@@ -13,9 +13,10 @@
 
 #define _GNU_SOURCE 1
 
-#include <stdio.h>
-#include <stdint.h>
 #include <inttypes.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -28,24 +29,6 @@
 #define LANES_DEF 1
 #define THREADS_DEF 1
 #define OUT_LEN 32
-#define SALT_LEN 16
-/* Sample encode:
- $argon2i$m=65536,t=2,p=4$c29tZXNhbHQAAAAAAAAAAA$QWLzI4TY9HkL2ZTLc8g6SinwdhZewYrzz9zxCo0bkGY
- * Maximumum lengths are defined as:
- * strlen $argon2i$ = 9
- * m=65536 with strlen (uint32_t)-1 = 10, so this total is 12
- * ,t=2,p=4 where each number could reach four digits in future, this = 14
- * $c29tZXNhbHQAAAAAAAAAAA Formula for this is (SALT_LEN * 4 + 3) / 3 + 1 = 23
- * $QWLzI4TY9HkL2ZTLc8g6SinwdhZewYrzz9zxCo0bkGY per above formula, = 44
- * + NULL byte
- * 9 + 12 + 14 + 23 + 44 + 1 = 103
- * Rounded to 4 byte boundary: 104
- *
- * WARNING: 104 is only for the parameters supported by this
-   command-line utility. You'll need a longer ENCODED_LEN to support
-   longer salts and ouputs, as supported by the argon2 library
- */
-#define ENCODED_LEN 108
 
 #define UNUSED_PARAMETER(x) (void)(x)
 
@@ -82,12 +65,11 @@ Base64-encoded hash string
 @threads actual parallelism
 @type String, only "d" and "i" are accepted
 */
-static void run(uint8_t *out, char *pwd, uint8_t *salt, uint32_t t_cost,
+static void run(uint8_t *out, char *pwd, char *salt, uint32_t t_cost,
                 uint32_t m_cost, uint32_t lanes, uint32_t threads,
                 argon2_type type) {
     clock_t start_time, stop_time;
-    size_t pwdlen;
-    char encoded[ENCODED_LEN];
+    size_t pwdlen, saltlen, encodedlen;
     uint32_t i;
     int result;
 
@@ -103,11 +85,27 @@ static void run(uint8_t *out, char *pwd, uint8_t *salt, uint32_t t_cost,
     }
 
     pwdlen = strlen(pwd);
+    saltlen = strlen(salt);
 
     UNUSED_PARAMETER(lanes);
 
-    result = argon2_hash(t_cost, m_cost, threads, pwd, pwdlen, salt, SALT_LEN,
-                         out, OUT_LEN, encoded, sizeof encoded, type);
+    /* 92 = sum of parameters max length + password length (32 chars in base64)
+       aka strlen("$argon2x$m=,t=,p=$$") = all info characters
+         + 1+log10(0xFFFFFFFF) = maximum memory cost, 2^32-1
+         + 1+log10(0xFFFFFF) = maximum iterations, 2^24-1
+         + 1+log10(0xFFFFFF) = maximum threads, 2^24 - 1
+         + 44 = base64 password
+         + null-byte = if one uses 16k iterations + 4gb memory + 16kk threads...
+    */
+    encodedlen = 92 + (size_t)(ceil(saltlen / 3.0) * 4);
+    char* encoded = malloc(encodedlen + 1);
+    if (!encoded) {
+        secure_wipe_memory(pwd, strlen(pwd));
+        fatal("could not allocate memory for hash");
+    }
+
+    result = argon2_hash(t_cost, m_cost, threads, pwd, pwdlen, salt, saltlen,
+                         out, OUT_LEN, encoded, encodedlen, type);
     if (result != ARGON2_OK)
         fatal(argon2_error_message(result));
 
@@ -127,6 +125,7 @@ static void run(uint8_t *out, char *pwd, uint8_t *salt, uint32_t t_cost,
     if (result != ARGON2_OK)
         fatal(argon2_error_message(result));
     printf("Verification ok\n");
+    free(encoded);
 }
 
 int main(int argc, char *argv[]) {
@@ -135,16 +134,17 @@ int main(int argc, char *argv[]) {
     uint32_t t_cost = T_COST_DEF;
     uint32_t lanes = LANES_DEF;
     uint32_t threads = THREADS_DEF;
-    uint8_t salt[SALT_LEN];
     argon2_type type = Argon2_i;
     int i;
     size_t n;
-    char pwd[128];
+    char pwd[128], *salt;
 
     if (argc < 2) {
         usage(argv[0]);
         return ARGON2_MISSING_ARGS;
     }
+
+    salt = argv[1];
 
     /* get password from stdin */
     while ((n = fread(pwd, 1, sizeof pwd - 1, stdin)) > 0) {
@@ -152,13 +152,6 @@ int main(int argc, char *argv[]) {
         if (pwd[n - 1] == '\n')
             pwd[n - 1] = '\0';
     }
-
-    /* get salt from command line */
-    if (strlen(argv[1]) > SALT_LEN) {
-        fatal("salt too long");
-    }
-    memset(salt, 0x00, SALT_LEN); /* pad with null bytes */
-    memcpy(salt, argv[1], strlen(argv[1]));
 
     /* parse options */
     for (i = 2; i < argc; i++) {


### PR DESCRIPTION
Fixes CLI tool to handle salts with length different than 16 and hash output length different than 32. Current behavior is to force salts to be 16 bytes long and pad if shorter and hash is hardcoded to 32 bytes. Updated behavior is:
```bash
$ echo -n "password" | ./argon2 somesaltextremelylargerthanexpectedmuchmuchlargerthanpreviouslywasallowed -t 2 -m 16 -p 4 -h 512
Type:		Argon2i
Iterations:	2 
Memory:		65536 KiB
Parallelism:	4 
Hash:		37d0a5e731f1c57966c2cd35c57597721c6d35d2dd07b5cdb14e306aba2e433587adc792e965a40be4f871d4fa9373563a08321654da2d2aa060bf941e380889cfa059686176c4e24bf0af1f7329016ded5dd8903f582cb773f5ca09cbf163db924baca32a2c131b6313fcd7c12fa03192c08fd5efee37c4a4cd675c7cbbf683ef87f61229e0fc0e720b03c16cae3fa10910437ad3b81165a156cab5e6691b1ba513e1e57d36c670b5334f5d4d4341603f80a996875b61f13e86255160e301d13dc2b4801a4bd4f8dff7c345072c141a9a0ff394db96e7b44fdf115ad4c9a33e7f765f6997e576e415281e1217d67b90066519a65d9c0e4426c2933a93bffbcb8ebf411b4846189fbe5592f2951c00abf3b803a843be6ab373e7bf9cf003c45edec4b4e4e6eb31587978379e9cbe96d44d132261306497aae6eccdc3f09f4792eb5ab882f9dcf12953c1bf0bf012d13fe20bd8dfb658dc03454f80df5db16ff1283ea75d58ed5638dbccb615c71ca7952e123a41474b7649b736f3a35cb8cd98ec7b7d2172690de72f64a10fc1ce0ec957beb42825bef9f76e88b7937aa353bf9853369472db9777d2b6b4ddc85b43493d33ee4c45558b62b5937605e9b613b43b157b852e49167387f809945c0432e1ea90a6d4785ef83cac1be6a91a11d87cd0c392b726c277b130c77fb4cb560e5d024b48873e9dc45d6f2dcfe5aac5d626
Encoded:	$argon2i$m=65536,t=2,p=4$c29tZXNhbHRleHRyZW1lbHlsYXJnZXJ0aGFuZXhwZWN0ZWRtdWNobXVjaGxhcmdlcnRoYW5wcmV2aW91c2x5d2FzYWxsb3dlZA$N9Cl5zHxxXlmws01xXWXchxtNdLdB7XNsU4warouQzWHrceS6WWkC+T4cdT6k3NWOggyFlTaLSqgYL+UHjgIic+gWWhhdsTiS/CvH3MpAW3tXdiQP1gst3P1ygnL8WPbkkusoyosExtjE/zXwS+gMZLAj9Xv7jfEpM1nXHy79oPvh/YSKeD8DnILA8Fsrj+hCRBDetO4EWWhVsq15mkbG6UT4eV9NsZwtTNPXU1DQWA/gKmWh1th8T6GJVFg4wHRPcK0gBpL1Pjf98NFBywUGpoP85Tblue0T98RWtTJoz5/dl9pl+V25BUoHhIX1nuQBmUZpl2cDkQmwpM6k7/7y46/QRtIRhifvlWS8pUcAKvzuAOoQ75qs3Pnv5zwA8Re3sS05ObrMVh5eDeenL6W1E0TImEwZJeq5uzNw/CfR5LrWriC+dzxKVPBvwvwEtE/4gvY37ZY3ANFT4DfXbFv8Sg+p11Y7VY428y2Fcccp5UuEjpBR0t2Sbc286NcuM2Y7Ht9IXJpDecvZKEPwc4OyVe+tCglvvn3boi3k3qjU7+YUzaUctuXd9K2tN3IW0NJPTPuTEVVi2K1k3YF6bYTtDsVe4UuSRZzh/gJlFwEMuHqkKbUeF74PKwb5qkaEdh80MOStybCd7Ewx3+0y1YOXQJLSIc+ncRdby3P5arF1iY
0.132 seconds
Verification ok
```
Also, it fixes the encoded buffer allocation to handle virtually whatever Argon2 is capable of, such as 16 million iterations and threads and up to 4GB of memory.