### PR TITLE
Remove test with m=20, as it takes too much RAM for many devices.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ OBJ = $(SRC:.c=.o)
 
 CFLAGS += -std=c89 -pthread -O3 -Wall -g -Iinclude -Isrc
 CI_CFLAGS := $(CFLAGS) -Werror=declaration-after-statement -D_FORTIFY_SOURCE=2 \
-				-Wextra -Wno-type-limits -Werror -coverage
+				-Wextra -Wno-type-limits -Werror -coverage -DTEST_LARGE_RAM
 
 OPTTEST := $(shell $(CC) -Iinclude -Isrc -march=native src/opt.c -c \
 			-o /dev/null 2>/dev/null; echo $$?)

--- a/src/test.c
+++ b/src/test.c
@@ -63,10 +63,12 @@ int main() {
              "f6c4db4a54e2a370627aff3db6176b94a2a209a62c8e36152711802f7b30c694",
              "$argon2i$m=65536,t=2,p=1$c29tZXNhbHQ"
              "$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ");
-    hashtest(version, 2, 20, 1, "password", "somesalt",
-             "9690ec55d28d3ed32562f2e73ea62b02b018757643a2ae6e79528459de8106e9",
-             "$argon2i$m=1048576,t=2,p=1$c29tZXNhbHQ"
-             "$lpDsVdKNPtMlYvLnPqYrArAYdXZDoq5ueVKEWd6BBuk");
+#ifdef TEST_LARGE_RAM
+    hashtest(version, 2, 20, 1, "password", "somesalt",  
+            "9690ec55d28d3ed32562f2e73ea62b02b018757643a2ae6e79528459de8106e9",
+            "$argon2i$m=1048576,t=2,p=1$c29tZXNhbHQ"
+            "$lpDsVdKNPtMlYvLnPqYrArAYdXZDoq5ueVKEWd6BBuk");
+#endif
     hashtest(version, 2, 18, 1, "password", "somesalt",
              "3e689aaa3d28a77cf2bc72a51ac53166761751182f1ee292e3f677a7da4c2467",
              "$argon2i$m=262144,t=2,p=1$c29tZXNhbHQ"
@@ -133,10 +135,12 @@ int main() {
              "c1628832147d9720c5bd1cfd61367078729f6dfb6f8fea9ff98158e0d7816ed0",
              "$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ"
              "$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
-    hashtest(version, 2, 20, 1, "password", "somesalt",
+#ifdef TEST_LARGE_RAM
+    hashtest(version, 2, 20, 1, "password", "somesalt",  
              "d1587aca0922c3b5d6a83edab31bee3c4ebaef342ed6127a55d19b2351ad1f41",
-             "$argon2i$v=19$m=1048576,t=2,p=1$c29tZXNhbHQ"
-             "$0Vh6ygkiw7XWqD7asxvuPE667zQu1hJ6VdGbI1GtH0E");
+             "$argon2i$v=19$m=1048576,t=2,p=1$c29tZXNhbHQ"  
+             "$0Vh6ygkiw7XWqD7asxvuPE667zQu1hJ6VdGbI1GtH0E");  
+#endif
     hashtest(version, 2, 18, 1, "password", "somesalt",
              "296dbae80b807cdceaad44ae741b506f14db0959267b183b118f9b24229bc7cb",
              "$argon2i$v=19$m=262144,t=2,p=1$c29tZXNhbHQ"


### PR DESCRIPTION
The m=20 test burns a GB of RAM. On an EC2 instance with only 512MB RAM, this test runs mostly in swap space, and runs for over 40 minutes. Obviously, this is undesirable.