### PR TITLE
Include lower-case "windows.h"

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -1,6 +1,6 @@
 #include "thread.h"
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 int argon2_thread_create(argon2_thread_handle_t *handle,


### PR DESCRIPTION
Capitalized Windows.h breaks on MinGW. "windows.h" is the proper include.