### PR TITLE
Improve handling of long passwords for command line utility.

### DIFF
--- a/src/run.c
+++ b/src/run.c
@@ -28,6 +28,7 @@
 #define LANES_DEF 1
 #define THREADS_DEF 1
 #define OUTLEN_DEF 32
+#define MAX_PASS_LEN 128
 
 #define UNUSED_PARAMETER(x) (void)(x)
 
@@ -161,7 +162,7 @@ int main(int argc, char *argv[]) {
     int raw_only = 0;
     int i;
     size_t n;
-    char pwd[128], *salt;
+    char pwd[MAX_PASS_LEN], *salt;
 
     if (argc < 2) {
         usage(argv[0]);
@@ -169,10 +170,17 @@ int main(int argc, char *argv[]) {
     }
 
     /* get password from stdin */
-    while ((n = fread(pwd, 1, sizeof pwd - 1, stdin)) > 0) {
-        pwd[n] = '\0';
-        if (pwd[n - 1] == '\n')
-            pwd[n - 1] = '\0';
+    n = fread(pwd, 1, sizeof pwd - 1, stdin);
+    if(n < 1) {
+        fatal("no password read");
+    }
+    if(n == MAX_PASS_LEN-1) {
+        fatal("Provided password longer than supported in command line utility");
+    }
+
+    pwd[n] = '\0';
+    if (pwd[n - 1] == '\n') {
+        pwd[n - 1] = '\0';
     }
 
     salt = argv[1];


### PR DESCRIPTION
The current read loop overwrites the buffer in a circular fashion, producing obvious issues. The following two commands produce identical output, which is obviously dangerous for a password hashing function:

    $ ruby -e "print 'a'*130" | ./argon2 somesalt -t 2 -m 16 -p 4 -h 24
    $ ruby -e "print 'a'*3" | ./argon2 somesalt -t 2 -m 16 -p 4 -h 24

Without delving into the complication of dynamic buffers, and given this only reads from stdin rather than a socket, I'm proposing a more simple solution is suited.