### PR TITLE
Properly zero pwd pointed before using it.

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -226,6 +226,8 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     ctx.free_cbk = NULL;
     ctx.secret = NULL;
     ctx.secretlen = 0;
+    ctx.pwdlen = 0;
+    ctx.pwd = NULL;
     ctx.ad = malloc(ctx.adlen);
     ctx.salt = malloc(ctx.saltlen);
     ctx.out = malloc(ctx.outlen);


### PR DESCRIPTION
argon2_verify creates an argon2_context, and configures a number of elements before passing it to decode_string. There, pwdlen is set to 0 and it is passed to validate_inputs.

There, pwd is used in a comparison as an uninitialized variable.