### PR TITLE
Ensure memset is not called with n == 0. This is undefined in C.

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -88,18 +88,12 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
     int result;
     uint8_t *out;
 
-    /* Detect and reject overflowing sizes */
-    /* TODO: This should probably be fixed in the function signature */
-    if (pwdlen > ARGON2_MAX_PWD_LENGTH) {
-        return ARGON2_PWD_TOO_LONG;
-    }
-
     if (hashlen > ARGON2_MAX_OUTLEN) {
         return ARGON2_OUTPUT_TOO_LONG;
     }
 
-    if (saltlen > ARGON2_MAX_SALT_LENGTH) {
-        return ARGON2_SALT_TOO_LONG;
+    if (hashlen < ARGON2_MIN_OUTLEN) {
+        return ARGON2_OUTPUT_TOO_SHORT;
     }
 
     out = malloc(hashlen);


### PR DESCRIPTION
It turns out calling memset() with n == 0 is undefined behaviour. This is discussed here:

http://stackoverflow.com/questions/8597034/can-memset-be-called-with-a-null-pointer-if-the-size-is-0

[tis-interpreter](https://github.com/TrustInSoft/tis-interpreter) has identified that the codebase does currently make such a call.

I cannot find definitive information regarding the other functions, however:
- I presume memset_s behaves the same
- [this discussion](https://gcc.gnu.org/ml/gcc/2015-09/msg00135.html) seems to suggest explicit_bzero should check for n == 0
- There is no suggestion anywhere that SecureZeroMemory behaves this way, that I can find

The implementation is messier than I would like - because simply placing this check at the start of the function messes with C89 compliance, where the function pointer is declared afterwards.
