### PR TITLE
Compile on Windows with MSYS2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ ifeq ($(findstring MINGW, $(KERNEL_NAME)), MINGW)
 	LIB_EXT := dll
 	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
 endif
+ifeq ($(findstring MSYS, $(KERNEL_NAME)), MSYS)
+	LIB_EXT := dll
+	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
+endif
 ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),OpenBSD FreeBSD))
 	LIB_EXT := so
 	LIB_CFLAGS := -shared -fPIC


### PR DESCRIPTION
Fixed the makefile so that argon2 is compilable on Windows with MSYS2.