### PR TITLE
Removed some warnings about possible loss of data …

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -212,7 +212,7 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     }
 
     /* max values, to be updated in decode_string */
-    encoded_len = strlen(encoded);
+    encoded_len = (uint32_t)strlen(encoded);
     ctx.adlen = encoded_len;
     ctx.saltlen = encoded_len;
     ctx.outlen = encoded_len;

--- a/src/run.c
+++ b/src/run.c
@@ -108,7 +108,7 @@ static void run(uint32_t outlen, char *pwd, char *salt, uint32_t t_cost,
         fatal("could not allocate memory for output");
     }
 
-    encodedlen = argon2_encodedlen(t_cost, m_cost, lanes, saltlen, outlen);
+    encodedlen = argon2_encodedlen(t_cost, m_cost, lanes, (uint32_t)saltlen, outlen);
     char* encoded = malloc(encodedlen + 1);
     if (!encoded) {
         secure_wipe_memory(pwd, strlen(pwd));


### PR DESCRIPTION
… due to automatic conversions from `size_t` to `uint32_t`.