### PR TITLE
run: use `-h` as command line option for usage help

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ results.
 
 `argon2` is a command-line utility to test specific Argon2 instances
 on your system. To show usage instructions, run
-`./argon2` without arguments as
+`./argon2 -h` as
 ```
-Usage:  ./argon2 salt [-d] [-t iterations] [-m memory] [-p parallelism] [-h hash length] [-e|-r]
+Usage:  ./argon2 [-h] salt [-d] [-t iterations] [-m memory] [-p parallelism] [-l hash length] [-e|-r]
         Password is read from stdin
 Parameters:
         salt            The salt to use, at least 8 characters 
@@ -58,15 +58,16 @@ Parameters:
         -t N            Sets the number of iterations to N (default = 3)
         -m N            Sets the memory usage of 2^N KiB (default 12)
         -p N            Sets parallelism to N threads (default 1)
-        -h N            Sets hash output length to N bytes (default 32)
+        -l N            Sets hash output length to N bytes (default 32)
         -e              Output only encoded hash
         -r              Output only the raw bytes of the hash
+        -h              Print argon2 usage
 ```
 For example, to hash "password" using "somesalt" as a salt and doing 2
 iterations, consuming 64 MiB, using four parallel threads and an output hash
 of 24 bytes
 ```
-$ echo -n "password" | ./argon2 somesalt -t 2 -m 16 -p 4 -h 24
+$ echo -n "password" | ./argon2 somesalt -t 2 -m 16 -p 4 -l 24
 Type:           Argon2i
 Iterations:     2
 Memory:         65536 KiB

--- a/man/argon2.1
+++ b/man/argon2.1
@@ -19,6 +19,9 @@ hashing and password-based key derivation.
 
 .SH OPTIONS
 .TP
+.B \-h
+Display tool usage
+.TP
 .B \-d
 Use Argon2d instead of Argon2i (Argon2i is the default)
 .TP
@@ -31,7 +34,7 @@ Sets the memory usage of 2^N KiB (default = 12)
 .BI \-p " N"
 Sets parallelism to N threads (default = 1)
 .TP
-.BI \-h " N"
+.BI \-l " N"
 Sets hash output length to N bytes (default = 32)
 .TP
 .B \-e

--- a/src/run.c
+++ b/src/run.c
@@ -33,8 +33,8 @@
 #define UNUSED_PARAMETER(x) (void)(x)
 
 static void usage(const char *cmd) {
-    printf("Usage:  %s salt [-d] [-t iterations] [-m memory] "
-           "[-p parallelism] [-h hash length] [-e|-r]\n",
+    printf("Usage:  %s [-h] salt [-d] [-t iterations] [-m memory] "
+           "[-p parallelism] [-l hash length] [-e|-r]\n",
            cmd);
     printf("\tPassword is read from stdin\n");
     printf("Parameters:\n");
@@ -46,10 +46,11 @@ static void usage(const char *cmd) {
            LOG_M_COST_DEF);
     printf("\t-p N\t\tSets parallelism to N threads (default %d)\n",
            THREADS_DEF);
-    printf("\t-h N\t\tSets hash output length to N bytes (default %d)\n",
+    printf("\t-l N\t\tSets hash output length to N bytes (default %d)\n",
            OUTLEN_DEF);
     printf("\t-e\t\tOutput only encoded hash\n");
     printf("\t-r\t\tOutput only the raw bytes of the hash\n");
+    printf("\t-h\t\tPrint %s usage\n", cmd);
 }
 
 static void fatal(const char *error) {
@@ -167,6 +168,9 @@ int main(int argc, char *argv[]) {
     if (argc < 2) {
         usage(argv[0]);
         return ARGON2_MISSING_ARGS;
+    } else if (argc >= 2 && strcmp(argv[1], "-h") == 0) {
+        usage(argv[0]);
+        return 1;
     }
 
     /* get password from stdin */
@@ -189,7 +193,10 @@ int main(int argc, char *argv[]) {
     for (i = 2; i < argc; i++) {
         const char *a = argv[i];
         unsigned long input = 0;
-        if (!strcmp(a, "-m")) {
+        if (!strcmp(a, "-h")) {
+            usage(argv[0]);
+            return 1;
+        } else if (!strcmp(a, "-m")) {
             if (i < argc - 1) {
                 i++;
                 input = strtoul(argv[i], NULL, 10);
@@ -232,14 +239,14 @@ int main(int argc, char *argv[]) {
             } else {
                 fatal("missing -p argument");
             }
-        } else if (!strcmp(a, "-h")) {
+        } else if (!strcmp(a, "-l")) {
             if (i < argc - 1) {
                 i++;
                 input = strtoul(argv[i], NULL, 10);
                 outlen = input;
                 continue;
             } else {
-                fatal("missing -h argument");
+                fatal("missing -l argument");
             }
         } else if (!strcmp(a, "-d")) {
             type = Argon2_d;


### PR DESCRIPTION
This commit adds `-h` as a command line option to display usage info, moving the existing hash length switch to `-l`.
This is a breaking change for existing scripts using `-h`.