### PR TITLE
Add support for building DLLs with Visual Studio

### DIFF
--- a/include/argon2.h
+++ b/include/argon2.h
@@ -24,6 +24,8 @@ extern "C" {
 /* Symbols visibility control */
 #ifdef A2_VISCTL
 #define ARGON2_PUBLIC __attribute__((visibility("default")))
+#elif _MSC_VER
+#define ARGON2_PUBLIC __declspec(dllexport)
 #else
 #define ARGON2_PUBLIC
 #endif


### PR DESCRIPTION
While previously Visual Studio would build the project just fine, the result would produce no exports, meaning that it would be useless as this is a library.