### PR TITLE
Fix bad pointer copy when using custom allocator

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -575,7 +575,7 @@ int initialize(argon2_instance_t *instance, argon2_context *context) {
         if (ARGON2_OK != result) {
             return result;
         }
-        memcpy(&(instance->memory), p, sizeof(instance->memory));
+        instance->memory = (block *)p;
     } else {
         result = allocate_memory(&(instance->memory), instance->memory_blocks);
         if (ARGON2_OK != result) {


### PR DESCRIPTION
In the original code, the contents of the allocated memory are copied to instance->memory instead of the actual pointer value. This patch fixes the bug and also simplifies the code.