### PR TITLE
Refactor fill_segment code

### DIFF
--- a/src/opt.c
+++ b/src/opt.c
@@ -58,56 +58,33 @@ void fill_block(__m128i *state, const block *ref_block, block *next_block,
     }
 }
 
-void generate_addresses(const argon2_instance_t *instance,
-                        const argon2_position_t *position,
-                        uint64_t *pseudo_rands) {
-    block address_block, input_block, tmp_block;
-    uint32_t i;
+static void next_addresses(block *address_block, block *input_block) {
+    /*Temporary zero-initialized blocks*/
+    __m128i zero_block[ARGON2_OWORDS_IN_BLOCK];
+    __m128i zero2_block[ARGON2_OWORDS_IN_BLOCK];
 
-    init_block_value(&address_block, 0);
-    init_block_value(&input_block, 0);
+    memset(zero_block, 0, sizeof(zero_block));
+    memset(zero2_block, 0, sizeof(zero2_block));
 
-    if (instance != NULL && position != NULL) {
-        input_block.v[0] = position->pass;
-        input_block.v[1] = position->lane;
-        input_block.v[2] = position->slice;
-        input_block.v[3] = instance->memory_blocks;
-        input_block.v[4] = instance->passes;
-        input_block.v[5] = instance->type;
+    /*Increasing index counter*/
+    input_block->v[6]++;
 
-        for (i = 0; i < instance->segment_length; ++i) {
-            if (i % ARGON2_ADDRESSES_IN_BLOCK == 0) {
-                /*Temporary zero-initialized blocks*/
-                __m128i zero_block[ARGON2_OWORDS_IN_BLOCK];
-                __m128i zero2_block[ARGON2_OWORDS_IN_BLOCK];
-                memset(zero_block, 0, sizeof(zero_block));
-                memset(zero2_block, 0, sizeof(zero2_block));
-                init_block_value(&address_block, 0);
-                init_block_value(&tmp_block, 0);
-                /*Increasing index counter*/
-                input_block.v[6]++;
-                /*First iteration of G*/
-                fill_block(zero_block, &input_block, &tmp_block, 1);
-                /*Second iteration of G*/
-                fill_block(zero2_block, &tmp_block, &address_block, 1);
-            }
+    /*First iteration of G*/
+    fill_block(zero_block, input_block, address_block, 0);
 
-            pseudo_rands[i] = address_block.v[i % ARGON2_ADDRESSES_IN_BLOCK];
-        }
-    }
+    /*Second iteration of G*/
+    fill_block(zero2_block, address_block, address_block, 0);
 }
 
 void fill_segment(const argon2_instance_t *instance,
                   argon2_position_t position) {
     block *ref_block = NULL, *curr_block = NULL;
+    block address_block, input_block;
     uint64_t pseudo_rand, ref_index, ref_lane;
     uint32_t prev_offset, curr_offset;
     uint32_t starting_index, i;
     __m128i state[64];
     int data_independent_addressing;
-
-    /* Pseudo-random values that determine the reference block position */
-    uint64_t *pseudo_rands = NULL;
 
     if (instance == NULL) {
         return;
@@ -115,20 +92,26 @@ void fill_segment(const argon2_instance_t *instance,
 
     data_independent_addressing = (instance->type == Argon2_i);
 
-    pseudo_rands =
-        (uint64_t *)malloc(sizeof(uint64_t) * instance->segment_length);
-    if (pseudo_rands == NULL) {
-        return;
-    }
-
     if (data_independent_addressing) {
-        generate_addresses(instance, &position, pseudo_rands);
+        init_block_value(&input_block, 0);
+
+        input_block.v[0] = position.pass;
+        input_block.v[1] = position.lane;
+        input_block.v[2] = position.slice;
+        input_block.v[3] = instance->memory_blocks;
+        input_block.v[4] = instance->passes;
+        input_block.v[5] = instance->type;
     }
 
     starting_index = 0;
 
     if ((0 == position.pass) && (0 == position.slice)) {
         starting_index = 2; /* we have already generated the first two blocks */
+
+        /* Don't forget to generate the first block of addresses: */
+        if (data_independent_addressing) {
+            next_addresses(&address_block, &input_block);
+        }
     }
 
     /* Offset of the current block */
@@ -155,7 +138,10 @@ void fill_segment(const argon2_instance_t *instance,
         /* 1.2 Computing the index of the reference block */
         /* 1.2.1 Taking pseudo-random value from the previous block */
         if (data_independent_addressing) {
-            pseudo_rand = pseudo_rands[i];
+            if (i % ARGON2_ADDRESSES_IN_BLOCK == 0) {
+                next_addresses(&address_block, &input_block);
+            }
+            pseudo_rand = address_block.v[i % ARGON2_ADDRESSES_IN_BLOCK];
         } else {
             pseudo_rand = instance->memory[prev_offset].v[0];
         }
@@ -190,6 +176,4 @@ void fill_segment(const argon2_instance_t *instance,
             }
         }
     }
-
-    free(pseudo_rands);
 }

--- a/src/opt.h
+++ b/src/opt.h
@@ -18,24 +18,15 @@
 #include <emmintrin.h>
 
 /*
- * Function fills a new memory block by XORing the new block over the old one. Memory must be initialized. 
- * After finishing, @state is identical to @next_block
+ * Function fills a new memory block and optionally XORs the old block over the new one.
+ * Memory must be initialized.
  * @param state Pointer to the just produced block. Content will be updated(!)
  * @param ref_block Pointer to the reference block
  * @param next_block Pointer to the block to be XORed over. May coincide with @ref_block
+ * @param with_xor Whether to XOR into the new block (1) or just overwrite (0)
  * @pre all block pointers must be valid
  */
-void fill_block_with_xor(__m128i *state, const uint8_t *ref_block, uint8_t *next_block);
-
-/* LEGACY CODE: version 1.2.1 and earlier
-* Function fills a new memory block by overwriting @next_block.
-* @param state Pointer to the just produced block. Content will be updated(!)
-* @param ref_block Pointer to the reference block
-* @param next_block Pointer to the block to be XORed over. May coincide with @ref_block
-* @pre all block pointers must be valid
-*/
-void fill_block(__m128i *state, const uint8_t *ref_block, uint8_t *next_block);
-
+void fill_block(__m128i *s, const block *ref_block, block *next_block, int with_xor);
 
 /*
  * Generate pseudo-random values to reference blocks in the segment and puts

--- a/src/opt.h
+++ b/src/opt.h
@@ -28,16 +28,4 @@
  */
 void fill_block(__m128i *s, const block *ref_block, block *next_block, int with_xor);
 
-/*
- * Generate pseudo-random values to reference blocks in the segment and puts
- * them into the array
- * @param instance Pointer to the current instance
- * @param position Pointer to the current position
- * @param pseudo_rands Pointer to the array of 64-bit values
- * @pre pseudo_rands must point to @a instance->segment_length allocated values
- */
-void generate_addresses(const argon2_instance_t *instance,
-                        const argon2_position_t *position,
-                        uint64_t *pseudo_rands);
-
 #endif /* ARGON2_OPT_H */

--- a/src/ref.c
+++ b/src/ref.c
@@ -24,53 +24,21 @@
 
 
 void fill_block(const block *prev_block, const block *ref_block,
-    block *next_block) {
+                block *next_block, int with_xor) {
     block blockR, block_tmp;
     unsigned i;
 
     copy_block(&blockR, ref_block);
     xor_block(&blockR, prev_block);
     copy_block(&block_tmp, &blockR);
-            /*Now blockR = ref_block + prev_block and bloc_tmp = ref_block + prev_block */
-                /* Apply Blake2 on columns of 64-bit words: (0,1,...,15) , then
-                (16,17,..31)... finally (112,113,...127) */
-    for (i = 0; i < 8; ++i) {
-        BLAKE2_ROUND_NOMSG(
-            blockR.v[16 * i], blockR.v[16 * i + 1], blockR.v[16 * i + 2],
-            blockR.v[16 * i + 3], blockR.v[16 * i + 4], blockR.v[16 * i + 5],
-            blockR.v[16 * i + 6], blockR.v[16 * i + 7], blockR.v[16 * i + 8],
-            blockR.v[16 * i + 9], blockR.v[16 * i + 10], blockR.v[16 * i + 11],
-            blockR.v[16 * i + 12], blockR.v[16 * i + 13], blockR.v[16 * i + 14],
-            blockR.v[16 * i + 15]);
+    /* Now blockR = ref_block + prev_block and block_tmp = ref_block + prev_block */
+    if (with_xor) {
+        /* Saving the next block contents for XOR over: */
+        xor_block(&block_tmp, next_block);
+        /* Now blockR = ref_block + prev_block and
+           block_tmp = ref_block + prev_block + next_block */
     }
 
-    /* Apply Blake2 on rows of 64-bit words: (0,1,16,17,...112,113), then
-    (2,3,18,19,...,114,115).. finally (14,15,30,31,...,126,127) */
-    for (i = 0; i < 8; i++) {
-        BLAKE2_ROUND_NOMSG(
-            blockR.v[2 * i], blockR.v[2 * i + 1], blockR.v[2 * i + 16],
-            blockR.v[2 * i + 17], blockR.v[2 * i + 32], blockR.v[2 * i + 33],
-            blockR.v[2 * i + 48], blockR.v[2 * i + 49], blockR.v[2 * i + 64],
-            blockR.v[2 * i + 65], blockR.v[2 * i + 80], blockR.v[2 * i + 81],
-            blockR.v[2 * i + 96], blockR.v[2 * i + 97], blockR.v[2 * i + 112],
-            blockR.v[2 * i + 113]);
-    }
-
-    copy_block(next_block, &block_tmp);
-    xor_block(next_block, &blockR);
-}
-
-
-void fill_block_with_xor(const block *prev_block, const block *ref_block,
-                block *next_block) {
-    block blockR, block_tmp;
-    unsigned i;
-
-    copy_block(&blockR, ref_block);
-    xor_block(&blockR, prev_block);
-    copy_block(&block_tmp, &blockR);
-    xor_block(&block_tmp, next_block); /*Saving the next block contents for XOR over*/
-    /*Now blockR = ref_block + prev_block and bloc_tmp = ref_block + prev_block + next_block*/
     /* Apply Blake2 on columns of 64-bit words: (0,1,...,15) , then
        (16,17,..31)... finally (112,113,...127) */
     for (i = 0; i < 8; ++i) {
@@ -121,8 +89,8 @@ void generate_addresses(const argon2_instance_t *instance,
                 input_block.v[6]++;
                 init_block_value(&tmp_block, 0);
                 init_block_value(&address_block, 0);
-                fill_block_with_xor(&zero_block, &input_block, &tmp_block);
-                fill_block_with_xor(&zero_block, &tmp_block, &address_block);
+                fill_block(&zero_block, &input_block, &tmp_block, 1);
+                fill_block(&zero_block, &tmp_block, &address_block, 1);
             }
 
             pseudo_rands[i] = address_block.v[i % ARGON2_ADDRESSES_IN_BLOCK];
@@ -212,14 +180,14 @@ void fill_segment(const argon2_instance_t *instance,
         curr_block = instance->memory + curr_offset;
         if (ARGON2_VERSION_10 == instance->version) {
             /* version 1.2.1 and earlier: overwrite, not XOR */
-            fill_block(instance->memory + prev_offset, ref_block, curr_block);
+            fill_block(instance->memory + prev_offset, ref_block, curr_block, 0);
         } else {
             if(0 == position.pass) {
                 fill_block(instance->memory + prev_offset, ref_block,
-                           curr_block);
+                           curr_block, 0);
             } else {
-                fill_block_with_xor(instance->memory + prev_offset, ref_block,
-                                    curr_block);
+                fill_block(instance->memory + prev_offset, ref_block,
+                           curr_block, 1);
             }
         }
     }

--- a/src/ref.h
+++ b/src/ref.h
@@ -28,16 +28,4 @@
 void fill_block(const block *prev_block, const block *ref_block,
                 block *next_block, int with_xor);
 
-/*
- * Generate pseudo-random values to reference blocks in the segment and puts
- * them into the array
- * @param instance Pointer to the current instance
- * @param position Pointer to the current position
- * @param pseudo_rands Pointer to the array of 64-bit values
- * @pre pseudo_rands must point to @a instance->segment_length allocated values
- */
-void generate_addresses(const argon2_instance_t *instance,
-                        const argon2_position_t *position,
-                        uint64_t *pseudo_rands);
-
 #endif /* ARGON2_REF_H */

--- a/src/ref.h
+++ b/src/ref.h
@@ -17,24 +17,16 @@
 #include "core.h"
 
 /*
- * Function fills a new memory block by XORing over @next_block. @next_block must be initialized
+ * Function fills a new memory block and optionally XORs the old block over the new one.
+ * @next_block must be initialized.
  * @param prev_block Pointer to the previous block
  * @param ref_block Pointer to the reference block
  * @param next_block Pointer to the block to be constructed
+ * @param with_xor Whether to XOR into the new block (1) or just overwrite (0)
  * @pre all block pointers must be valid
  */
-void fill_block_with_xor(const block *prev_block, const block *ref_block,
-                block *next_block);
-
-/* LEGACY CODE: version 1.2.1 and earlier
-* Function fills a new memory block by overwriting @next_block. 
-* @param prev_block Pointer to the previous block
-* @param ref_block Pointer to the reference block
-* @param next_block Pointer to the block to be constructed
-* @pre all block pointers must be valid
-*/
 void fill_block(const block *prev_block, const block *ref_block,
-    block *next_block);
+                block *next_block, int with_xor);
 
 /*
  * Generate pseudo-random values to reference blocks in the segment and puts


### PR DESCRIPTION
This PR attempts to de-duplicate and simplify the code for the fill_segment function and its helper functions.

Summary of changes:
- fill_block and fill_block_with_xor are merged into a single function
- fill_block in opt.c now accepts block pointers instead of uint8_t pointers
- Argon2i pseudo-random addresses are now computed on-the-fly instead of pre-computing them into a dynamically allocated buffer
- the above change also fixes a serious bug where fill_segment would silently give up and do nothing if the allocation failed