### PR TITLE
Eliminate redundant function.

### DIFF
--- a/src/blake2/blake2-impl.h
+++ b/src/blake2/blake2-impl.h
@@ -134,10 +134,6 @@ static BLAKE2_INLINE uint64_t rotr64(const uint64_t w, const unsigned c) {
     return (w >> c) | (w << (64 - c));
 }
 
-/* prevents compiler optimizing out memset() */
-static BLAKE2_INLINE void burn(void *v, size_t n) {
-    static void *(*const volatile memset_v)(void *, int, size_t) = &memset;
-    memset_v(v, 0, n);
-}
+void secure_wipe_memory(void *v, size_t n);
 
 #endif

--- a/src/blake2/blake2b.c
+++ b/src/blake2/blake2b.c
@@ -44,7 +44,7 @@ static BLAKE2_INLINE void blake2b_increment_counter(blake2b_state *S,
 }
 
 static BLAKE2_INLINE void blake2b_invalidate_state(blake2b_state *S) {
-    burn(S, sizeof(*S));      /* wipe */
+    secure_wipe_memory(S, sizeof(*S));      /* wipe */
     blake2b_set_lastblock(S); /* invalidate for further use */
 }
 
@@ -140,7 +140,7 @@ int blake2b_init_key(blake2b_state *S, size_t outlen, const void *key,
         memset(block, 0, BLAKE2B_BLOCKBYTES);
         memcpy(block, key, keylen);
         blake2b_update(S, block, BLAKE2B_BLOCKBYTES);
-        burn(block, BLAKE2B_BLOCKBYTES); /* Burn the key from stack */
+        secure_wipe_memory(block, BLAKE2B_BLOCKBYTES); /* Burn the key from stack */
     }
     return 0;
 }
@@ -267,9 +267,9 @@ int blake2b_final(blake2b_state *S, void *out, size_t outlen) {
     }
 
     memcpy(out, buffer, S->outlen);
-    burn(buffer, sizeof(buffer));
-    burn(S->buf, sizeof(S->buf));
-    burn(S->h, sizeof(S->h));
+    secure_wipe_memory(buffer, sizeof(buffer));
+    secure_wipe_memory(S->buf, sizeof(S->buf));
+    secure_wipe_memory(S->h, sizeof(S->h));
     return 0;
 }
 
@@ -307,7 +307,7 @@ int blake2b(void *out, size_t outlen, const void *in, size_t inlen,
     ret = blake2b_final(&S, out, outlen);
 
 fail:
-    burn(&S, sizeof(S));
+    secure_wipe_memory(&S, sizeof(S));
     return ret;
 }
 
@@ -365,7 +365,7 @@ int blake2b_long(void *pout, size_t outlen, const void *in, size_t inlen) {
         memcpy(out, out_buffer, toproduce);
     }
 fail:
-    burn(&blake_state, sizeof(blake_state));
+    secure_wipe_memory(&blake_state, sizeof(blake_state));
     return ret;
 #undef TRY
 }


### PR DESCRIPTION
Both burn() and secure_wipe_memory() serve identical functions.

This patch addresses code reuse. I also have the following concerns about the existing code:
- burn() does not have the NOT_OPTIMIZED attribute. 
- burn() does not OpenBSD or Windows specific variants

I'm unsure how important some of these are, but discrepancies like this are a good reason to reuse functions. I don't *think* it matters that a prototype doesn't use the attribute, since nothing is compiled there.
