### PR TITLE
Add argon2themax binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ their documentation):
 * [Go](https://github.com/tvdburgt/go-argon2) by [@tvdburgt](https://github.com/tvdburgt)
 * [Haskell](https://hackage.haskell.org/package/argon2-1.0.0/docs/Crypto-Argon2.html) by [@ocharles](https://github.com/ocharles)
 * [JavaScript (native)](https://github.com/ranisalt/node-argon2), by [@ranisalt](https://github.com/ranisalt)
+* [JavaScript (native)](https://github.com/jdconley/argon2themax), by [@jdconley](https://github.com/jdconley)
 * [JavaScript (ffi)](https://github.com/cjlarose/argon2-ffi), by [@cjlarose](https://github.com/cjlarose)
 * [JavaScript (browser)](https://github.com/antelle/argon2-browser), by [@antelle](https://github.com/antelle)
 * [JVM](https://github.com/phxql/argon2-jvm) by [@phXql](https://github.com/phxql)


### PR DESCRIPTION
Include my new library in the Bindings section.

To be fair, it is just a proxy to the argon2 lib by @ranisalt. However, argon2themax includes a bench-like utility which will automatically choose the most costly Argon2 options within a given clock time ceiling. This allows engineers to easily choose an option that is more secure than the default on whatever system they are running on and still maintain a good user experience.

For instance, you can ask for an option set that takes up to 100ms to run, and the library will march through increasingly costly options to find a set that hits as close to 100ms, without going over, as possible.

Since it isn't strictly a new binding maybe there should be another section in the README for stuff like this?