### PR TITLE
fix memory leak in fill_memory_blocks

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -277,6 +277,7 @@ int fill_memory_blocks(argon2_instance_t *instance) {
         for (s = 0; s < ARGON2_SYNC_POINTS; ++s) {
             int rc;
             uint32_t l;
+            int join_error = 0;
 
             /* 2. Calling threads */
             for (l = 0; l < instance->lanes; ++l) {
@@ -318,8 +319,11 @@ int fill_memory_blocks(argon2_instance_t *instance) {
                  ++l) {
                 rc = argon2_thread_join(thread[l]);
                 if (rc) {
-                    return ARGON2_THREAD_FAIL;
+                    join_error = 1;
                 }
+            }
+            if (join_error) {
+                return ARGON2_THREAD_FAIL;
             }
         }
 

--- a/src/core.c
+++ b/src/core.c
@@ -278,7 +278,6 @@ int fill_memory_blocks(argon2_instance_t *instance) {
 
     for (r = 0; r < instance->passes; ++r) {
         for (s = 0; s < ARGON2_SYNC_POINTS; ++s) {
-            int rc;
             uint32_t l;
 
             /* 2. Calling threads */

--- a/src/core.c
+++ b/src/core.c
@@ -317,8 +317,7 @@ int fill_memory_blocks(argon2_instance_t *instance) {
             /* 3. Joining remaining threads */
             for (l = instance->lanes - instance->threads; l < instance->lanes;
                  ++l) {
-                rc = argon2_thread_join(thread[l]);
-                if (rc) {
+                if (argon2_thread_join(thread[l])) {
                     rc = ARGON2_THREAD_FAIL;
                     goto fail;
                 }

--- a/src/core.c
+++ b/src/core.c
@@ -287,8 +287,7 @@ int fill_memory_blocks(argon2_instance_t *instance) {
 
                 /* 2.1 Join a thread if limit is exceeded */
                 if (l >= instance->threads) {
-                    rc = argon2_thread_join(thread[l - instance->threads]);
-                    if (rc) {
+                    if (argon2_thread_join(thread[l - instance->threads])) {
                         rc = ARGON2_THREAD_FAIL;
                         goto fail;
                     }
@@ -303,9 +302,8 @@ int fill_memory_blocks(argon2_instance_t *instance) {
                     instance; /* preparing the thread input */
                 memcpy(&(thr_data[l].pos), &position,
                        sizeof(argon2_position_t));
-                rc = argon2_thread_create(&thread[l], &fill_segment_thr,
-                                          (void *)&thr_data[l]);
-                if (rc) {
+                if (argon2_thread_create(&thread[l], &fill_segment_thr,
+                                         (void *)&thr_data[l])) {
                     rc = ARGON2_THREAD_FAIL;
                     goto fail;
                 }

--- a/src/core.c
+++ b/src/core.c
@@ -256,28 +256,30 @@ int fill_memory_blocks(argon2_instance_t *instance) {
     uint32_t r, s;
     argon2_thread_handle_t *thread = NULL;
     argon2_thread_data *thr_data = NULL;
+    int rc = ARGON2_OK;
 
     if (instance == NULL || instance->lanes == 0) {
-        return ARGON2_THREAD_FAIL;
+        rc = ARGON2_THREAD_FAIL;
+        goto fail;
     }
 
     /* 1. Allocating space for threads */
     thread = calloc(instance->lanes, sizeof(argon2_thread_handle_t));
     if (thread == NULL) {
-        return ARGON2_MEMORY_ALLOCATION_ERROR;
+        rc = ARGON2_MEMORY_ALLOCATION_ERROR;
+        goto fail;
     }
 
     thr_data = calloc(instance->lanes, sizeof(argon2_thread_data));
     if (thr_data == NULL) {
-        free(thread);
-        return ARGON2_MEMORY_ALLOCATION_ERROR;
+        rc = ARGON2_MEMORY_ALLOCATION_ERROR;
+        goto fail;
     }
 
     for (r = 0; r < instance->passes; ++r) {
         for (s = 0; s < ARGON2_SYNC_POINTS; ++s) {
             int rc;
             uint32_t l;
-            int join_error = 0;
 
             /* 2. Calling threads */
             for (l = 0; l < instance->lanes; ++l) {
@@ -287,9 +289,8 @@ int fill_memory_blocks(argon2_instance_t *instance) {
                 if (l >= instance->threads) {
                     rc = argon2_thread_join(thread[l - instance->threads]);
                     if (rc) {
-                        free(thr_data);
-                        free(thread);
-                        return ARGON2_THREAD_FAIL;
+                        rc = ARGON2_THREAD_FAIL;
+                        goto fail;
                     }
                 }
 
@@ -305,9 +306,8 @@ int fill_memory_blocks(argon2_instance_t *instance) {
                 rc = argon2_thread_create(&thread[l], &fill_segment_thr,
                                           (void *)&thr_data[l]);
                 if (rc) {
-                    free(thr_data);
-                    free(thread);
-                    return ARGON2_THREAD_FAIL;
+                    rc = ARGON2_THREAD_FAIL;
+                    goto fail;
                 }
 
                 /* fill_segment(instance, position); */
@@ -319,13 +319,9 @@ int fill_memory_blocks(argon2_instance_t *instance) {
                  ++l) {
                 rc = argon2_thread_join(thread[l]);
                 if (rc) {
-                    join_error = 1;
+                    rc = ARGON2_THREAD_FAIL;
+                    goto fail;
                 }
-            }
-            if (join_error) {
-                free(thr_data);
-                free(thread);
-                return ARGON2_THREAD_FAIL;
             }
         }
 
@@ -334,13 +330,14 @@ int fill_memory_blocks(argon2_instance_t *instance) {
 #endif
     }
 
+fail:
     if (thread != NULL) {
         free(thread);
     }
     if (thr_data != NULL) {
         free(thr_data);
     }
-    return ARGON2_OK;
+    return rc;
 }
 
 int validate_inputs(const argon2_context *context) {

--- a/src/core.c
+++ b/src/core.c
@@ -323,6 +323,8 @@ int fill_memory_blocks(argon2_instance_t *instance) {
                 }
             }
             if (join_error) {
+                free(thr_data);
+                free(thread);
                 return ARGON2_THREAD_FAIL;
             }
         }


### PR DESCRIPTION
This patch fixes memory leak of a localy heap allocated 'threads' variable in fill_memory_blocks().
The leak happens in case of failure of argon2_thread_join(), needed to wait end of just created threads.