### PR TITLE
Fixed up encoding issues

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -354,37 +354,37 @@ int validate_inputs(const argon2_context *context) {
         return ARGON2_OUTPUT_TOO_LONG;
     }
 
-    /* Validate password length */
+    /* Validate password (required param) */
     if (NULL == context->pwd) {
         if (0 != context->pwdlen) {
             return ARGON2_PWD_PTR_MISMATCH;
         }
-    } else {
-        if (ARGON2_MIN_PWD_LENGTH > context->pwdlen) {
-            return ARGON2_PWD_TOO_SHORT;
-        }
-
-        if (ARGON2_MAX_PWD_LENGTH < context->pwdlen) {
-            return ARGON2_PWD_TOO_LONG;
-        }
     }
 
-    /* Validate salt length */
+    if (ARGON2_MIN_PWD_LENGTH > context->pwdlen) {
+      return ARGON2_PWD_TOO_SHORT;
+    }
+
+    if (ARGON2_MAX_PWD_LENGTH < context->pwdlen) {
+        return ARGON2_PWD_TOO_LONG;
+    }
+
+    /* Validate salt (required param) */
     if (NULL == context->salt) {
         if (0 != context->saltlen) {
             return ARGON2_SALT_PTR_MISMATCH;
         }
-    } else {
-        if (ARGON2_MIN_SALT_LENGTH > context->saltlen) {
-            return ARGON2_SALT_TOO_SHORT;
-        }
-
-        if (ARGON2_MAX_SALT_LENGTH < context->saltlen) {
-            return ARGON2_SALT_TOO_LONG;
-        }
     }
 
-    /* Validate secret length */
+    if (ARGON2_MIN_SALT_LENGTH > context->saltlen) {
+        return ARGON2_SALT_TOO_SHORT;
+    }
+
+    if (ARGON2_MAX_SALT_LENGTH < context->saltlen) {
+        return ARGON2_SALT_TOO_LONG;
+    }
+
+    /* Validate secret (optional param) */
     if (NULL == context->secret) {
         if (0 != context->secretlen) {
             return ARGON2_SECRET_PTR_MISMATCH;
@@ -393,13 +393,12 @@ int validate_inputs(const argon2_context *context) {
         if (ARGON2_MIN_SECRET > context->secretlen) {
             return ARGON2_SECRET_TOO_SHORT;
         }
-
         if (ARGON2_MAX_SECRET < context->secretlen) {
             return ARGON2_SECRET_TOO_LONG;
         }
     }
 
-    /* Validate associated data */
+    /* Validate associated data (optional param) */
     if (NULL == context->ad) {
         if (0 != context->adlen) {
             return ARGON2_AD_PTR_MISMATCH;
@@ -408,7 +407,6 @@ int validate_inputs(const argon2_context *context) {
         if (ARGON2_MIN_AD_LENGTH > context->adlen) {
             return ARGON2_AD_TOO_SHORT;
         }
-
         if (ARGON2_MAX_AD_LENGTH < context->adlen) {
             return ARGON2_AD_TOO_LONG;
         }

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -39,11 +39,6 @@
  *   the parameters, salts and outputs. It does not compute the hash
  *   itself.
  *
- *   -- The third section is test code, with a main() function. With
- *   this section, the whole file compiles as a stand-alone program
- *   that exercises the encoding and decoding functions with some
- *   test vectors.
- *
  * The code was originally written by Thomas Pornin <pornin@bolet.org>,
  * to whom comments and remarks may be sent. It is released under what
  * should amount to Public Domain or its closest equivalent; the
@@ -246,19 +241,18 @@ static const char *decode_decimal(const char *str, unsigned long *v) {
  *
  * The code below applies the following format:
  *
- *  $argon2<T>[$v=<num>]$m=<num>,t=<num>,p=<num>[,keyid=<bin>][,data=<bin>][$<bin>[$<bin>]]
+ *  $argon2<T>[$v=<num>]$m=<num>,t=<num>,p=<num>$<bin>$<bin>
  *
- * where <T> is either 'd' or 'i', <num> is a decimal integer (positive, fits in
- * an 'unsigned long'), and <bin> is Base64-encoded data (no '=' padding
+ * where <T> is either 'd', 'id', or 'i', <num> is a decimal integer (positive,
+ * fits in an 'unsigned long'), and <bin> is Base64-encoded data (no '=' padding
  * characters, no newline or whitespace).
- * The "keyid" is a binary identifier for a key (up to 8 bytes);
- * "data" is associated data (up to 32 bytes). When the 'keyid'
- * (resp. the 'data') is empty, then it is ommitted from the output.
  *
  * The last two binary chunks (encoded in Base64) are, in that order,
- * the salt and the output. Both are optional, but you cannot have an
- * output without a salt. The binary salt length is between 8 and 48 bytes.
- * The output length is always exactly 32 bytes.
+ * the salt and the output. Both are required. The binary salt length and the
+ * output length must be in the permisable ranges as defined in argon2.h.
+ *
+ * The ctx struct must contain buffers large enough to hold the salt and pwd
+ * when it is fed into decode_string.
  */
 
 int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
@@ -273,7 +267,7 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
         str += cc_len;                                                         \
     } while ((void)0, 0)
 
-/* prefix checking with supplied code */
+/* optional prefix checking with supplied code */
 #define CC_opt(prefix, code)                                                   \
     do {                                                                       \
         size_t cc_len = strlen(prefix);                                        \
@@ -283,7 +277,7 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
         }                                                                      \
     } while ((void)0, 0)
 
-/* Decoding  prefix into decimal */
+/* Decoding prefix into decimal */
 #define DECIMAL(x)                                                             \
     do {                                                                       \
         unsigned long dec_x;                                                   \
@@ -294,6 +288,7 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
         (x) = dec_x;                                                           \
     } while ((void)0, 0)
 
+/* Decoding base64 into a binary buffer */
 #define BIN(buf, max_len, len)                                                 \
     do {                                                                       \
         size_t bin_len = (max_len);                                            \
@@ -304,25 +299,22 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
         (len) = (uint32_t)bin_len;                                             \
     } while ((void)0, 0)
 
-    size_t maxadlen = ctx->adlen;
     size_t maxsaltlen = ctx->saltlen;
     size_t maxoutlen = ctx->outlen;
     int validation_result;
     const char* type_string;
 
-    ctx->adlen = 0;
     ctx->saltlen = 0;
     ctx->outlen = 0;
-    ctx->pwdlen = 0;
 
     /* We should start with the argon2_type we are using */
-    CC("$");
     type_string = argon2_type2string(type, 0);
-    if (type_string) {
-        CC(type_string);
-    } else {
+    if (!type_string) {
         return ARGON2_INCORRECT_TYPE;
     }
+
+    CC("$");
+    CC(type_string);
 
     /* Reading the version number if the default is suppressed */
     ctx->version = ARGON2_VERSION_10;
@@ -336,17 +328,11 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
     DECIMAL(ctx->lanes);
     ctx->threads = ctx->lanes;
 
-    CC_opt(",data=", BIN(ctx->ad, maxadlen, ctx->adlen));
-    if (*str == 0) {
-        return ARGON2_OK;
-    }
     CC("$");
     BIN(ctx->salt, maxsaltlen, ctx->saltlen);
-    if (*str == 0) {
-        return ARGON2_OK;
-    }
     CC("$");
     BIN(ctx->out, maxoutlen, ctx->outlen);
+
     validation_result = validate_inputs(ctx);
     if (validation_result != ARGON2_OK) {
         return validation_result;
@@ -393,19 +379,23 @@ int encode_string(char *dst, size_t dst_len, argon2_context *ctx,
     } while ((void)0, 0)
 
     const char* type_string = argon2_type2string(type, 0);
-    SS("$");
-    if (type_string) {
-        SS(type_string);
-    } else {
-        return ARGON2_ENCODING_FAIL;
+    int validation_result = validate_inputs(ctx);
+
+    if (!type_string) {
+      return ARGON2_ENCODING_FAIL;
     }
 
-    if (validate_inputs(ctx) != ARGON2_OK) {
-        return validate_inputs(ctx);
+    if (validation_result != ARGON2_OK) {
+      return validation_result;
     }
+
+
+    SS("$");
+    SS(type_string);
 
     SS("$v=");
     SX(ctx->version);
+
     SS("$m=");
     SX(ctx->m_cost);
     SS(",t=");
@@ -413,19 +403,8 @@ int encode_string(char *dst, size_t dst_len, argon2_context *ctx,
     SS(",p=");
     SX(ctx->lanes);
 
-    if (ctx->adlen > 0) {
-        SS(",data=");
-        SB(ctx->ad, ctx->adlen);
-    }
-
-    if (ctx->saltlen == 0)
-        return ARGON2_OK;
-
     SS("$");
     SB(ctx->salt, ctx->saltlen);
-
-    if (ctx->outlen == 0)
-        return ARGON2_OK;
 
     SS("$");
     SB(ctx->out, ctx->outlen);

--- a/src/test.c
+++ b/src/test.c
@@ -128,8 +128,15 @@ int main() {
     ret = argon2_verify("$argon2i$m=65536,t=2,p=1$c29tZXNhbHQ"
                         "9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ",
                         "password", strlen("password"), Argon2_i);
-    assert(ret == ARGON2_OUTPUT_TOO_SHORT);
+    assert(ret == ARGON2_DECODING_FAIL);
     printf("Recognise an invalid encoding: PASS\n");
+
+    /* Handle an invalid encoding correctly (salt is too short) */
+    ret = argon2_verify("$argon2i$m=65536,t=2,p=1$"
+                        "$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ",
+                        "password", strlen("password"), Argon2_i);
+    assert(ret == ARGON2_SALT_TOO_SHORT);
+    printf("Recognise an invalid salt in encoding: PASS\n");
 
     /* Handle an mismatching hash (the encoded password is "passwore") */
     ret = argon2_verify("$argon2i$m=65536,t=2,p=1$c29tZXNhbHQ"
@@ -200,8 +207,15 @@ int main() {
     ret = argon2_verify("$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ"
                         "wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA",
                         "password", strlen("password"), Argon2_i);
-    assert(ret == ARGON2_OUTPUT_TOO_SHORT);
+    assert(ret == ARGON2_DECODING_FAIL);
     printf("Recognise an invalid encoding: PASS\n");
+
+    /* Handle an invalid encoding correctly (salt is too short) */
+    ret = argon2_verify("$argon2i$v=19$m=65536,t=2,p=1$"
+                        "$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ",
+                        "password", strlen("password"), Argon2_i);
+    assert(ret == ARGON2_SALT_TOO_SHORT);
+    printf("Recognise an invalid salt in encoding: PASS\n");
 
     /* Handle an mismatching hash (the encoded password is "passwore") */
     ret = argon2_verify("$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ"


### PR DESCRIPTION
I significantly constrained the space of admissible encodings to deal with #143 . 

The `keyid` and `data` parameters in the encoding are gone, as they are either not used in validation, or they cause validation to fail. Similarly, the salt is now required. Before if no salt was provided, the encoding wouldn't include the salt or the hash value. Because there was no hash value, any later validation check would fail.

I also made changes to `validate_context`. Empty vs. `NULL` passwords and salts now produce the same results and errors. The salt was the real outlier here, a `NULL` salt was allowed while an empty salt produced an error (`ARGON2_SALT_TOO_SHORT`). This is inconsistent with the rest of Argon2, where switching a  parameter from empty to `NULL` produces the exact same hash value (or produces the exact same error).

Note that this doesn't break virtually any consumers of the public API in `argon2.h` because all encodings emitted from functions like `argon2_hash()` are still valid. There are only two cases where an existing consumer would see breakage:

1. They had manually added a `data` parameter to the string encoding. Note that this parameter has always been ignored.

2. They were hashing with a `NULL` salt (because hashing with an empty salt doesn't work). This is quite insecure, and they already would have been unable to use `argon2_verify()` as it would just fail when decoding the encoded string. 

I also added tests for a bad salt in an encoding string.