### PR TITLE
Cleaned up encoding issues

### DIFF
--- a/src/encoding.c
+++ b/src/encoding.c
@@ -304,9 +304,6 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
     int validation_result;
     const char* type_string;
 
-    ctx->saltlen = 0;
-    ctx->outlen = 0;
-
     /* We should start with the argon2_type we are using */
     type_string = argon2_type2string(type, 0);
     if (!type_string) {
@@ -333,10 +330,22 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
     CC("$");
     BIN(ctx->out, maxoutlen, ctx->outlen);
 
+    /* The rest of the fields get the default values */
+    ctx->secret = NULL;
+    ctx->secretlen = 0;
+    ctx->ad = NULL;
+    ctx->adlen = 0;
+    ctx->allocate_cbk = NULL;
+    ctx->free_cbk = NULL;
+    ctx->flags = ARGON2_DEFAULT_FLAGS;
+
+    /* On return, must have valid context */
     validation_result = validate_inputs(ctx);
     if (validation_result != ARGON2_OK) {
         return validation_result;
     }
+
+    /* Can't have any additional characters */
     if (*str == 0) {
         return ARGON2_OK;
     } else {

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -29,21 +29,21 @@
 * is less than the number of required characters (including the
 * terminating 0), then this function returns ARGON2_ENCODING_ERROR.
 *
-* if ctx->outlen is 0, then the hash string will be a salt string
-* (no output). if ctx->saltlen is also 0, then the string will be a
-* parameter-only string (no salt and no output).
-*
 * on success, ARGON2_OK is returned.
-*
-* No other parameters are checked
 */
 int encode_string(char *dst, size_t dst_len, argon2_context *ctx,
                   argon2_type type);
 
 /*
 * Decodes an Argon2 hash string into the provided structure 'ctx'.
-* The fields ctx.saltlen, ctx.adlen, ctx.outlen set the maximal salt, ad, out
-* length values that are allowed; invalid input string causes an error.
+* The only fields that must be set prior to this call are ctx.saltlen and
+* ctx.outlen (which must be the maximal salt and out length values that are
+* allowed), ctx.salt and ctx.out (which must be buffers of the specified
+* length), and ctx.pwd and ctx.pwdlen which must hold a valid password.
+*
+* Invalid input string causes an error. On success, the ctx is valid and all
+* fields have been initialized.
+*
 * Returned value is ARGON2_OK on success, other ARGON2_ codes on error.
 */
 int decode_string(argon2_context *ctx, const char *str, argon2_type type);


### PR DESCRIPTION
This fixes some issues in Issue #143 that I didn't get fixed in PR #173 

Specifically this change
- Clarifies which function is responsible for setting which values (between `argon2_verify()` and `decode_string()`
- Improves memory error handling in `argon2_verify()`
- Changes `argon2_verify()` to use `argon2_verify_context()` so that the comparisons are always done with `argon2_compare()` which compares in constant time. Before, `argon2_verify()` was using `memcmp`, potentially exposing a side channel attack.