### PR TITLE
Allow setting Argon2 version number from the command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ results. `make install PREFIX=/usr` installs it to your system.
 on your system. To show usage instructions, run
 `./argon2 -h` as
 ```
-Usage:  ./argon2 [-h] salt [-i|-d|-id] [-t iterations] [-m memory] [-p parallelism] [-l hash length] [-e|-r] [-10|-13]
+Usage:  ./argon2 [-h] salt [-i|-d|-id] [-t iterations] [-m memory] [-p parallelism] [-l hash length] [-e|-r] [-v (10|13)]
         Password is read from stdin
 Parameters:
         salt            The salt to use, at least 8 characters
@@ -67,8 +67,7 @@ Parameters:
         -l N            Sets hash output length to N bytes (default 32)
         -e              Output only encoded hash
         -r              Output only the raw bytes of the hash
-        -10             Argon2 v1.0
-        -13             Argon2 v1.3
+        -v (10|13)      Argon2 version
         -h              Print argon2 usage
 ```
 For example, to hash "password" using "somesalt" as a salt and doing 2

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Parameters:
         -l N            Sets hash output length to N bytes (default 32)
         -e              Output only encoded hash
         -r              Output only the raw bytes of the hash
-        -v (10|13)      Argon2 version
+        -v (10|13)      Argon2 version (defaults to the most recent version, currently 13)
         -h              Print argon2 usage
 ```
 For example, to hash "password" using "somesalt" as a salt and doing 2

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ results. `make install PREFIX=/usr` installs it to your system.
 on your system. To show usage instructions, run
 `./argon2 -h` as
 ```
-Usage:  ./argon2 [-h] salt [-i|-d|-id] [-t iterations] [-m memory] [-p parallelism] [-l hash length] [-e|-r]
+Usage:  ./argon2 [-h] salt [-i|-d|-id] [-t iterations] [-m memory] [-p parallelism] [-l hash length] [-e|-r] [-10|-13]
         Password is read from stdin
 Parameters:
         salt            The salt to use, at least 8 characters
@@ -67,6 +67,8 @@ Parameters:
         -l N            Sets hash output length to N bytes (default 32)
         -e              Output only encoded hash
         -r              Output only the raw bytes of the hash
+        -10             Argon2 v1.0
+        -13             Argon2 v1.3
         -h              Print argon2 usage
 ```
 For example, to hash "password" using "somesalt" as a salt and doing 2

--- a/man/argon2.1
+++ b/man/argon2.1
@@ -46,11 +46,8 @@ Output only encoded hash
 .B \-r
 Output only the raw bytes of the hash
 .TP
-.B \-10
-Argon2 v1.0
-.TP
-.B \-13
-Argon2 v1.3
+.B \-v (10|13)
+Argon2 version
 
 .SH COPYRIGHT
 This manpage was written by \fBDaniel Kahn Gillmor\fR for the Debian

--- a/man/argon2.1
+++ b/man/argon2.1
@@ -47,7 +47,7 @@ Output only encoded hash
 Output only the raw bytes of the hash
 .TP
 .B \-v (10|13)
-Argon2 version
+Argon2 version (defaults to the most recent version, currently 13)
 
 .SH COPYRIGHT
 This manpage was written by \fBDaniel Kahn Gillmor\fR for the Debian

--- a/man/argon2.1
+++ b/man/argon2.1
@@ -45,6 +45,12 @@ Output only encoded hash
 .TP
 .B \-r
 Output only the raw bytes of the hash
+.TP
+.B \-10
+Argon2 v1.0
+.TP
+.B \-13
+Argon2 v1.3
 
 .SH COPYRIGHT
 This manpage was written by \fBDaniel Kahn Gillmor\fR for the Debian

--- a/src/run.c
+++ b/src/run.c
@@ -56,7 +56,8 @@ static void usage(const char *cmd) {
            OUTLEN_DEF);
     printf("\t-e\t\tOutput only encoded hash\n");
     printf("\t-r\t\tOutput only the raw bytes of the hash\n");
-    printf("\t-v (10|13)\tArgon2 version\n");
+    printf("\t-v (10|13)\tArgon2 version (defaults to the most recent version, currently %x)\n",
+            ARGON2_VERSION_NUMBER);
     printf("\t-h\t\tPrint %s usage\n", cmd);
 }
 

--- a/src/run.c
+++ b/src/run.c
@@ -38,7 +38,7 @@
 
 static void usage(const char *cmd) {
     printf("Usage:  %s [-h] salt [-i|-d|-id] [-t iterations] [-m memory] "
-           "[-p parallelism] [-l hash length] [-e|-r]\n",
+           "[-p parallelism] [-l hash length] [-e|-r] [-10|-13]\n",
            cmd);
     printf("\tPassword is read from stdin\n");
     printf("Parameters:\n");
@@ -56,6 +56,8 @@ static void usage(const char *cmd) {
            OUTLEN_DEF);
     printf("\t-e\t\tOutput only encoded hash\n");
     printf("\t-r\t\tOutput only the raw bytes of the hash\n");
+    printf("\t-10\t\tArgon2 v1.0\n");
+    printf("\t-13\t\tArgon2 v1.3\n");
     printf("\t-h\t\tPrint %s usage\n", cmd);
 }
 
@@ -85,10 +87,11 @@ Base64-encoded hash string
 @type Argon2 type we want to run
 @encoded_only display only the encoded hash
 @raw_only display only the hexadecimal of the hash
+@version Argon2 version
 */
 static void run(uint32_t outlen, char *pwd, char *salt, uint32_t t_cost,
                 uint32_t m_cost, uint32_t lanes, uint32_t threads,
-                argon2_type type, int encoded_only, int raw_only) {
+                argon2_type type, int encoded_only, int raw_only, uint32_t version) {
     clock_t start_time, stop_time;
     size_t pwdlen, saltlen, encodedlen;
     int result;
@@ -129,7 +132,7 @@ static void run(uint32_t outlen, char *pwd, char *salt, uint32_t t_cost,
 
     result = argon2_hash(t_cost, m_cost, threads, pwd, pwdlen, salt, saltlen,
                          out, outlen, encoded, encodedlen, type,
-                         ARGON2_VERSION_NUMBER);
+                         version);
     if (result != ARGON2_OK)
         fatal(argon2_error_message(result));
 
@@ -173,6 +176,7 @@ int main(int argc, char *argv[]) {
     int types_specified = 0;
     int encoded_only = 0;
     int raw_only = 0;
+    uint32_t version = ARGON2_VERSION_NUMBER;
     int i;
     size_t n;
     char pwd[MAX_PASS_LEN], *salt;
@@ -273,6 +277,10 @@ int main(int argc, char *argv[]) {
             encoded_only = 1;
         } else if (!strcmp(a, "-r")) {
             raw_only = 1;
+        } else if (!strcmp(a, "-10")) {
+            version = ARGON2_VERSION_10;
+        } else if (!strcmp(a, "-13")) {
+            version = ARGON2_VERSION_13;
         } else {
             fatal("unknown argument");
         }
@@ -293,7 +301,7 @@ int main(int argc, char *argv[]) {
     }
 
     run(outlen, pwd, salt, t_cost, m_cost, lanes, threads, type,
-       encoded_only, raw_only);
+       encoded_only, raw_only, version);
 
     return ARGON2_OK;
 }

--- a/src/run.c
+++ b/src/run.c
@@ -38,7 +38,7 @@
 
 static void usage(const char *cmd) {
     printf("Usage:  %s [-h] salt [-i|-d|-id] [-t iterations] [-m memory] "
-           "[-p parallelism] [-l hash length] [-e|-r] [-10|-13]\n",
+           "[-p parallelism] [-l hash length] [-e|-r] [-v (10|13)]\n",
            cmd);
     printf("\tPassword is read from stdin\n");
     printf("Parameters:\n");
@@ -56,8 +56,7 @@ static void usage(const char *cmd) {
            OUTLEN_DEF);
     printf("\t-e\t\tOutput only encoded hash\n");
     printf("\t-r\t\tOutput only the raw bytes of the hash\n");
-    printf("\t-10\t\tArgon2 v1.0\n");
-    printf("\t-13\t\tArgon2 v1.3\n");
+    printf("\t-v (10|13)\tArgon2 version\n");
     printf("\t-h\t\tPrint %s usage\n", cmd);
 }
 
@@ -277,10 +276,19 @@ int main(int argc, char *argv[]) {
             encoded_only = 1;
         } else if (!strcmp(a, "-r")) {
             raw_only = 1;
-        } else if (!strcmp(a, "-10")) {
-            version = ARGON2_VERSION_10;
-        } else if (!strcmp(a, "-13")) {
-            version = ARGON2_VERSION_13;
+        } else if (!strcmp(a, "-v")) {
+            if (i < argc - 1) {
+                i++;
+                if (!strcmp(argv[i], "10")) {
+                    version = ARGON2_VERSION_10;
+                } else if (!strcmp(argv[i], "13")) {
+                    version = ARGON2_VERSION_13;
+                } else {
+                    fatal("invalid Argon2 version");
+                }
+            } else {
+                fatal("missing -v argument");
+            }
         } else {
             fatal("unknown argument");
         }


### PR DESCRIPTION
Those flags allow one to make sure that the generated hashes are consistents over time even if the `argon2` binary is updated.