### PR TITLE
Shared library fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BENCH = bench
 GENKAT = genkat
 
 # Increment on an ABI breaking change
-ABIVERSION = 1
+ABI_VERSION = 0
 
 DIST = phc-winner-argon2
 
@@ -52,7 +52,7 @@ KERNEL_NAME := $(shell uname -s)
 
 LIB_NAME=argon2
 ifeq ($(KERNEL_NAME), Linux)
-	LIB_EXT := so.$(ABIVERSION)
+	LIB_EXT := so.$(ABI_VERSION)
 	LIB_CFLAGS := -shared -fPIC -fvisibility=hidden -DA2_VISCTL=1
 	SO_LDFLAGS := -Wl,-soname,lib$(LIB_NAME).$(LIB_EXT)
 	LINKED_LIB_EXT := so
@@ -62,7 +62,7 @@ ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),FreeBSD NetBSD OpenBSD))
 	LIB_CFLAGS := -shared -fPIC
 endif
 ifeq ($(KERNEL_NAME), Darwin)
-	LIB_EXT := $(ABIVERSION).dylib
+	LIB_EXT := $(ABI_VERSION).dylib
 	LIB_CFLAGS := -dynamiclib -install_name @rpath/lib$(LIB_NAME).$(LIB_EXT)
 	LINKED_LIB_EXT := dylib
 endif

--- a/Makefile
+++ b/Makefile
@@ -173,3 +173,11 @@ ifdef LINKED_LIB_SH
 endif
 	$(INSTALL) -d $(INST_BINARY)
 	$(INSTALL) $(RUN) $(INST_BINARY)
+
+uninstall:
+	cd $(INST_INCLUDE) && rm -f $(HEADERS)
+	cd $(INST_LIBRARY) && rm -f $(LIBRARIES)
+ifdef LINKED_LIB_SH
+	cd $(INST_LIBRARY) && rm -f $(LINKED_LIB_SH)
+endif
+	cd $(INST_BINARY) && rm -f $(RUN)

--- a/Makefile
+++ b/Makefile
@@ -165,19 +165,16 @@ format:
 
 install: $(RUN) libs
 	$(INSTALL) -d $(INST_INCLUDE)
-	$(INSTALL) $(HEADERS) $(INST_INCLUDE)
+	$(INSTALL) -m 0644 $(HEADERS) $(INST_INCLUDE)
 	$(INSTALL) -d $(INST_LIBRARY)
 	$(INSTALL) $(LIBRARIES) $(INST_LIBRARY)
 ifdef LINKED_LIB_SH
-	ln -rs $(INST_LIBRARY)/$(LIB_SH) $(INST_LIBRARY)/$(LINKED_LIB_SH)
+	cd $(INST_LIBRARY) && ln -s $(notdir $(LIB_SH) $(LINKED_LIB_SH))
 endif
 	$(INSTALL) -d $(INST_BINARY)
 	$(INSTALL) $(RUN) $(INST_BINARY)
 
 uninstall:
-	cd $(INST_INCLUDE) && rm -f $(HEADERS)
-	cd $(INST_LIBRARY) && rm -f $(LIBRARIES)
-ifdef LINKED_LIB_SH
-	cd $(INST_LIBRARY) && rm -f $(LINKED_LIB_SH)
-endif
-	cd $(INST_BINARY) && rm -f $(RUN)
+	cd $(INST_INCLUDE) && rm -f $(notdir $(HEADERS))
+	cd $(INST_LIBRARY) && rm -f $(notdir $(LIBRARIES) $(LINKED_LIB_SH))
+	cd $(INST_BINARY) && rm -f $(notdir $(RUN))


### PR DESCRIPTION
The commit fixed #184, taking the "Fix 2" approach of dealing with the ABI Versioning.

This commit adds an `ABIVERSION` variable in the make file that should be incremented on every breaking change. Then, for Linux and macOS (Darwin), the name of the shared library is modified to include the version number. The unversioned shared library is then linked to this specific version.

As the install has gotten slightly more complicated, I also added an uninstall command for additional convenience. I also did a bit of formatting cleanup and set the correct permissions on the installed headers.

Tested on Ubuntu Linux (64 bit 3.13.0-105-generic) and macOS 10.11.6 (Darwin 15.6.0)

On linux:
Installed with `sudo make install`.
Compiled (with `gcc -Wall test.c -largon2 -o test`) and ran dynamically linked test from #184.
Compiled (with `gcc -Wall -static test.c -largon2 -pthread -o test`) and ran statically linked test from #184.
Uninstalled with `sudo make uninstall`

On macOS:
Ran Install/Uninstall with `make install PREFIX=~` and `sudo make install PREFIX=/usr/local`.
Compiled (with `gcc -Wall test.c -largon2 -o test`) and ran dynamically linked test from #184.
Compiled (with `gcc -Wall test.c /usr/local/lib/libargon2.a -o test`) and ran statically linked test from #184.