### PR TITLE
Remove fill_block function from opt.h and ref.h.

### DIFF
--- a/src/opt.h
+++ b/src/opt.h
@@ -21,15 +21,4 @@
 #include "core.h"
 #include <emmintrin.h>
 
-/*
- * Function fills a new memory block and optionally XORs the old block over the new one.
- * Memory must be initialized.
- * @param state Pointer to the just produced block. Content will be updated(!)
- * @param ref_block Pointer to the reference block
- * @param next_block Pointer to the block to be XORed over. May coincide with @ref_block
- * @param with_xor Whether to XOR into the new block (1) or just overwrite (0)
- * @pre all block pointers must be valid
- */
-void fill_block(__m128i *s, const block *ref_block, block *next_block, int with_xor);
-
 #endif /* ARGON2_OPT_H */

--- a/src/ref.h
+++ b/src/ref.h
@@ -20,16 +20,4 @@
 
 #include "core.h"
 
-/*
- * Function fills a new memory block and optionally XORs the old block over the new one.
- * @next_block must be initialized.
- * @param prev_block Pointer to the previous block
- * @param ref_block Pointer to the reference block
- * @param next_block Pointer to the block to be constructed
- * @param with_xor Whether to XOR into the new block (1) or just overwrite (0)
- * @pre all block pointers must be valid
- */
-void fill_block(const block *prev_block, const block *ref_block,
-                block *next_block, int with_xor);
-
 #endif /* ARGON2_REF_H */


### PR DESCRIPTION
Remove the fill_block function from opt.h and ref.h since it is not used outside opt.c and ref.c.