### PR TITLE
Fix comment in fill_first_blocks.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -501,8 +501,8 @@ int validate_inputs(const argon2_context *context) {
 
 void fill_first_blocks(uint8_t *blockhash, const argon2_instance_t *instance) {
     uint32_t l;
-    /* Make the first and second block in each lane as G(H0||i||0) or
-       G(H0||i||1) */
+    /* Make the first and second block in each lane as G(H0||0||i) or
+       G(H0||1||i) */
     uint8_t blockhash_bytes[ARGON2_BLOCK_SIZE];
     for (l = 0; l < instance->lanes; ++l) {
 


### PR DESCRIPTION
The index and value arguments to the G function are swapped in the comment.