### PR TITLE
Check for overflow on input lengths

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -104,6 +104,14 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
     int result;
     uint8_t *out;
 
+    if (pwdlen > ARGON2_MAX_PWD_LENGTH) {
+        return ARGON2_PWD_TOO_LONG;
+    }
+
+    if (saltlen > ARGON2_MAX_SALT_LENGTH) {
+        return ARGON2_SALT_TOO_LONG;
+    }
+
     if (hashlen > ARGON2_MAX_OUTLEN) {
         return ARGON2_OUTPUT_TOO_LONG;
     }
@@ -245,6 +253,10 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     size_t encoded_len;
     uint32_t max_field_len;
 
+    if (pwdlen > ARGON2_MAX_PWD_LENGTH) {
+        return ARGON2_PWD_TOO_LONG;
+    }
+
     if (encoded == NULL) {
         return ARGON2_DECODING_FAIL;
     }
@@ -268,7 +280,7 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     }
 
     ctx.pwd = (uint8_t *)pwd;
-    ctx.pwdlen = pwdlen;
+    ctx.pwdlen = (uint32_t)pwdlen;
 
     ret = decode_string(&ctx, encoded, type);
     if (ret != ARGON2_OK) {


### PR DESCRIPTION
On 64-bit architectures it is currently possible to have passwords that hash and verify to the same value, as demonstrated below:

```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <assert.h>

#include "argon2.h"

int main(void) {
    unsigned char out[32];
    char encoded[108];
    int ret;

    const char pwd[] = "a not very long password";
    const char salt[] = "a very long salt";

    ret = argon2_hash(2, 1 << 16, 1, pwd, strlen(pwd), salt, strlen(salt), out,
                      sizeof(out), encoded, sizeof(encoded), Argon2_i, ARGON2_VERSION_13);
    assert(ret == ARGON2_OK);

    ret = argon2_verify(encoded, pwd, strlen(pwd), Argon2_i);
    assert(ret == ARGON2_OK);

    char * pwd2 = (char *)calloc(strlen(pwd) + (1ULL << 32) + 1, 1);
    memset(pwd2, 'A', strlen(pwd) + (1ULL << 32));
    memcpy(pwd2, pwd, strlen(pwd));

    ret = argon2_verify(encoded, pwd2, strlen(pwd2), Argon2_i);
    assert(ret == ARGON2_OK);

    printf("BUG\n");
}
```

The reason for this is that `argon2_verify` receives a `size_t` password length, but it is converted to `uint32_t` before being verified in `validate_inputs`. Therefore truncation can occur.

Checks to prevent this used to exist on `argon2_hash` but were removed in #131. On `argon2_verify`, as far as I can tell, they never existed.