### PR TITLE
Fix use after free if threads > lanes

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -72,6 +72,10 @@ int argon2_ctx(argon2_context *context, argon2_type type) {
     instance.threads = context->threads;
     instance.type = type;
 
+    if (instance.threads > instance.lanes) {
+        instance.threads = instance.lanes;
+    }
+
     /* 3. Initialization: Hashing inputs, allocating memory, filling first
      * blocks
      */


### PR DESCRIPTION
In [this `for` loop](https://github.com/P-H-C/phc-winner-argon2/blob/f15cf8bacd6594fdc51948959675bbf7d74666c3/src/core.c#L337), (reproduced below)

````c
uint32_t l;
for (l = instance->lanes - instance->threads; l < instance->lanes;
     ++l) {
    if (argon2_thread_join(thread[l])) {
        rc = ARGON2_THREAD_FAIL;
        goto fail;
    }
}
````

if `threads` is more than `lanes` (which is not specified to be illegal) `l` underflows. None of the threads will be joined and `argon2_ctx` may return before all the threads end, which means the `argon2_instance_t` instance is freed while threads are using it.

This mostly causes SIGSEGVs and SIGFPEs.

There doesn't seem to be any point if `threads` > `lanes` so just (silently) limiting `threads` to `lanes` fixes this.