### PR TITLE
Fixed compiler warnings about potential dangerous casts

### DIFF
--- a/src/encoding.c
+++ b/src/encoding.c
@@ -288,6 +288,19 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
         (x) = dec_x;                                                           \
     } while ((void)0, 0)
 
+
+/* Decoding prefix into uint32_t decimal */
+#define DECIMAL_U32(x)                                                         \
+    do {                                                                       \
+        unsigned long dec_x;                                                   \
+        str = decode_decimal(str, &dec_x);                                     \
+        if (str == NULL || dec_x > UINT32_MAX) {                               \
+            return ARGON2_DECODING_FAIL;                                       \
+        }                                                                      \
+        (x) = (uint32_t)dec_x;                                                 \
+    } while ((void)0, 0)
+
+
 /* Decoding base64 into a binary buffer */
 #define BIN(buf, max_len, len)                                                 \
     do {                                                                       \
@@ -315,14 +328,14 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
 
     /* Reading the version number if the default is suppressed */
     ctx->version = ARGON2_VERSION_10;
-    CC_opt("$v=", DECIMAL(ctx->version));
+    CC_opt("$v=", DECIMAL_U32(ctx->version));
 
     CC("$m=");
-    DECIMAL(ctx->m_cost);
+    DECIMAL_U32(ctx->m_cost);
     CC(",t=");
-    DECIMAL(ctx->t_cost);
+    DECIMAL_U32(ctx->t_cost);
     CC(",p=");
-    DECIMAL(ctx->lanes);
+    DECIMAL_U32(ctx->lanes);
     ctx->threads = ctx->lanes;
 
     CC("$");

--- a/src/run.c
+++ b/src/run.c
@@ -27,7 +27,7 @@
 #include "argon2.h"
 #include "core.h"
 
-#define T_COST_DEF 3
+#define T_COST_DEF 16
 #define LOG_M_COST_DEF 12 /* 2^12 = 4 MiB */
 #define LANES_DEF 1
 #define THREADS_DEF 1


### PR DESCRIPTION
Casting unsigned long to uint32_t is not guaranteed to be a safe operation as a long int can also be 64 bit wide and very often it is 64 bit wide. This change silences a couple of compiler warnings I got while building the code.