### PR TITLE
Remove unused ALIGN macro

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -20,14 +20,6 @@
 
 #include "argon2.h"
 
-#if defined(_MSC_VER)
-#define ALIGN(n) __declspec(align(16))
-#elif defined(__GNUC__) || defined(__clang)
-#define ALIGN(x) __attribute__((__aligned__(x)))
-#else
-#define ALIGN(x)
-#endif
-
 #define CONST_CAST(x) (x)(uintptr_t)
 
 /**********************Argon2 internal constants*******************************/


### PR DESCRIPTION
The 'ALIGN' macro defined in core.h is not used anywhere, so it can be removed.