### PR TITLE
add support for fine-grained memory setting

### DIFF
--- a/src/run.c
+++ b/src/run.c
@@ -50,7 +50,7 @@ static void usage(const char *cmd) {
            T_COST_DEF);
     printf("\t-m N\t\tSets the memory usage of 2^N KiB (default %d)\n",
            LOG_M_COST_DEF);
-    printf("\t-k N\t\tSets the memory usage N KiB (default %d)\n",
+    printf("\t-k N\t\tSets the memory usage of N KiB (default %d)\n",
            1 << LOG_M_COST_DEF);
     printf("\t-p N\t\tSets parallelism to N threads (default %d)\n",
            THREADS_DEF);

--- a/src/run.c
+++ b/src/run.c
@@ -37,8 +37,9 @@
 #define UNUSED_PARAMETER(x) (void)(x)
 
 static void usage(const char *cmd) {
-    printf("Usage:  %s [-h] salt [-i|-d|-id] [-t iterations] [-m log2(memory in KiB)] "
-           "[-k memory in KiB] [-p parallelism] [-l hash length] [-e|-r] [-v (10|13)]\n",
+    printf("Usage:  %s [-h] salt [-i|-d|-id] [-t iterations] "
+           "[-m log2(memory in KiB) | -k memory in KiB] [-p parallelism] "
+           "[-l hash length] [-e|-r] [-v (10|13)]\n",
            cmd);
     printf("\tPassword is read from stdin\n");
     printf("Parameters:\n");
@@ -176,6 +177,7 @@ int main(int argc, char *argv[]) {
     uint32_t threads = THREADS_DEF;
     argon2_type type = Argon2_i; /* Argon2i is the default type */
     int types_specified = 0;
+    int m_cost_specified = 0;
     int encoded_only = 0;
     int raw_only = 0;
     uint32_t version = ARGON2_VERSION_NUMBER;
@@ -215,6 +217,10 @@ int main(int argc, char *argv[]) {
             usage(argv[0]);
             return 1;
         } else if (!strcmp(a, "-m")) {
+            if (m_cost_specified) {
+                fatal("-m or -k can only be used once");
+            }
+            m_cost_specified = 1;
             if (i < argc - 1) {
                 i++;
                 input = strtoul(argv[i], NULL, 10);
@@ -231,6 +237,10 @@ int main(int argc, char *argv[]) {
                 fatal("missing -m argument");
             }
         } else if (!strcmp(a, "-k")) {
+            if (m_cost_specified) {
+                fatal("-m or -k can only be used once");
+            }
+            m_cost_specified = 1;
             if (i < argc - 1) {
                 i++;
                 input = strtoul(argv[i], NULL, 10);


### PR DESCRIPTION
to fix https://github.com/P-H-C/phc-winner-argon2/issues/211

This is the simplest patch I could think of. Let me know whether/how I should add tests for it (i.e. should I change the way all existing tests are using m_cost, or add some new cases, or something else).

The mnemonic I have for `-k` is "KiBs of memory" - suggestions for a different letter are welcome.