### PR TITLE
Remove dependency of inttypes.h

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -25,7 +25,6 @@
 #endif
 #define VC_GE_2005(version) (version >= 1400)
 
-#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/genkat.c
+++ b/src/genkat.c
@@ -115,7 +115,7 @@ void internal_kat(const argon2_instance_t *instance, uint32_t pass) {
                     : ARGON2_QWORDS_IN_BLOCK;
 
             for (j = 0; j < how_many_words; ++j)
-                printf("Block %.4u [%3u]: %016" PRIx64 "\n", i, j,
+                printf("Block %.4u [%3u]: %016llx\n", i, j,
                        instance->memory[i].v[j]);
         }
     }

--- a/src/genkat.c
+++ b/src/genkat.c
@@ -15,7 +15,6 @@
  * software. If not, they may be obtained at the above URLs.
  */
 
-#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/genkat.c
+++ b/src/genkat.c
@@ -116,7 +116,7 @@ void internal_kat(const argon2_instance_t *instance, uint32_t pass) {
 
             for (j = 0; j < how_many_words; ++j)
                 printf("Block %.4u [%3u]: %016llx\n", i, j,
-                       instance->memory[i].v[j]);
+                       (unsigned long long)instance->memory[i].v[j]);
         }
     }
 }

--- a/src/run.c
+++ b/src/run.c
@@ -35,10 +35,6 @@
 
 #define UNUSED_PARAMETER(x) (void)(x)
 
-#ifndef PRIu32
-#define PRIu32 "I32u"
-#endif
-
 static void usage(const char *cmd) {
     printf("Usage:  %s [-h] salt [-i|-d|-id] [-t iterations] "
            "[-m log2(memory in KiB) | -k memory in KiB] [-p parallelism] "
@@ -328,9 +324,9 @@ int main(int argc, char *argv[]) {
 
     if(!encoded_only && !raw_only) {
         printf("Type:\t\t%s\n", argon2_type2string(type, 1));
-        printf("Iterations:\t%" PRIu32 " \n", t_cost);
-        printf("Memory:\t\t%" PRIu32 " KiB\n", m_cost);
-        printf("Parallelism:\t%" PRIu32 " \n", lanes);
+        printf("Iterations:\t%u\n", t_cost);
+        printf("Memory:\t\t%u KiB\n", m_cost);
+        printf("Parallelism:\t%u\n", lanes);
     }
 
     run(outlen, pwd, pwdlen, salt, t_cost, m_cost, lanes, threads, type,

--- a/src/run.c
+++ b/src/run.c
@@ -17,7 +17,6 @@
 
 #define _GNU_SOURCE 1
 
-#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,6 +34,10 @@
 #define MAX_PASS_LEN 128
 
 #define UNUSED_PARAMETER(x) (void)(x)
+
+#ifndef PRIu32
+#define PRIu32 "I32u"
+#endif
 
 static void usage(const char *cmd) {
     printf("Usage:  %s [-h] salt [-i|-d|-id] [-t iterations] "

--- a/src/test.c
+++ b/src/test.c
@@ -17,7 +17,6 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
Fixes #205 and removes some includes that weren't necessary. Since the only required macro from that file was `PRIu32` I copied it to the file that needed it.