### PR TITLE
saltlen change to size_t in run.c

### DIFF
--- a/include/argon2.h
+++ b/include/argon2.h
@@ -424,7 +424,7 @@ ARGON2_PUBLIC const char *argon2_error_message(int error_code);
  * @return  The encoded hash length in bytes
  */
 ARGON2_PUBLIC size_t argon2_encodedlen(uint32_t t_cost, uint32_t m_cost,
-                                       uint32_t parallelism, uint32_t saltlen,
+                                       uint32_t parallelism, size_t saltlen,
                                        uint32_t hashlen, argon2_type type);
 
 #if defined(__cplusplus)

--- a/src/argon2.c
+++ b/src/argon2.c
@@ -445,8 +445,8 @@ const char *argon2_error_message(int error_code) {
 }
 
 size_t argon2_encodedlen(uint32_t t_cost, uint32_t m_cost, uint32_t parallelism,
-                         uint32_t saltlen, uint32_t hashlen, argon2_type type) {
+                         size_t saltlen, uint32_t hashlen, argon2_type type) {
   return strlen("$$v=$m=,t=,p=$$") + strlen(argon2_type2string(type, 0)) +
          numlen(t_cost) + numlen(m_cost) + numlen(parallelism) +
-         b64len(saltlen) + b64len(hashlen) + numlen(ARGON2_VERSION_NUMBER) + 1;
+         saltlen + b64len(hashlen) + numlen(ARGON2_VERSION_NUMBER) + 1;
 }

--- a/src/run.c
+++ b/src/run.c
@@ -125,7 +125,7 @@ static void run(uint32_t outlen, char *pwd, size_t pwdlen, char *salt, uint32_t 
         fatal("could not allocate memory for output");
     }
 
-    encodedlen = argon2_encodedlen(t_cost, m_cost, lanes, (uint32_t)saltlen, outlen, type);
+    encodedlen = argon2_encodedlen(t_cost, m_cost, lanes, saltlen, outlen, type);
     encoded = malloc(encodedlen + 1);
     if (!encoded) {
         clear_internal_memory(pwd, pwdlen);


### PR DESCRIPTION
argon2_encodedlen now takes saltlen of type size_t

Fixes #201 