### PR TITLE
bump ABI version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BENCH = bench
 GENKAT = genkat
 
 # Increment on an ABI breaking change
-ABI_VERSION = 0
+ABI_VERSION = 1
 
 DIST = phc-winner-argon2
 


### PR DESCRIPTION
Before commit 5e78398c (Added ABI Version Number, and properly handle
it for Linux and Darwin) the library was installed as `libargon2.so`,
though the soname was `libargon2.so.0`. Actually installing a package
with that file makes `ldconfig` create a symbolic link matching the
soname. That file does not  belong to the package and is not managed by
the package manager.

Building a package from current git master results in the library file
`libargon2.so.0` being included in the package. That conflicts with the
file formerly created by `ldconfig`.

So bump the ABI version for a conflict-free transition to current code.