### PR TITLE
Allow changing PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,9 @@ HEADERS = include/argon2.h
 INSTALL = install
 
 DESTDIR =
+ifndef PREFIX
 PREFIX = /usr
+endif
 INCLUDE_REL = include
 LIBRARY_REL = lib
 BINARY_REL = bin


### PR DESCRIPTION
Without this change it is not possible to change PREFIX to something
else, since the Makefile simply overrides it.