### PR TITLE
Spelling and updated function name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ int main(void)
 }
 ```
 
-To use Argon2d instead of Argon2i call `argon2d_hash` instead of
-`argon2i_hash` using the high-level API, and `argon2d` instead of
-`argon2i` using the low-level API. Similarly for Argon2id, call `argond2id_hash`
+To use Argon2d instead of Argon2i call `argon2d_hash_raw` instead of
+`argon2i_hash_raw` using the high-level API, and `argon2d` instead of
+`argon2i` using the low-level API. Similarly for Argon2id, call `argon2id_hash_raw`
 and `argon2id`.
 
 To produce the crypt-like encoding rather than the raw hash, call


### PR DESCRIPTION
Also I couldn't find the "low-level API" functions `argon2i`, `argon2d`, and `argon2id`. Were these removed or did I not look hard enough?