### PR TITLE
Ignore all build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 argon2
 libargon2.a
-libargon2.so
+libargon2.so*
 libargon2.dylib
 .DS_Store
 src/*.o


### PR DESCRIPTION
With the ABI changes to libargon2, libargon2.so.1 wasn't ignored.