### PR TITLE
All headers should be self-contained

### DIFF
--- a/src/genkat.h
+++ b/src/genkat.h
@@ -18,6 +18,8 @@
 #ifndef ARGON2_KAT_H
 #define ARGON2_KAT_H
 
+#include "core.h"
+
 /*
  * Initial KAT function that prints the inputs to the file
  * @param  blockhash  Array that contains pre-hashing digest


### PR DESCRIPTION
Adding an include of core.h to genkat.h makes it so genkat.h will
compile on it's own. All other headers in the project have this
property.

This was causing warnings when importing argon2 into other build systems
like Bazel/Blaze.