### PR TITLE
Remove the need for stdio.h (sprintf)

### DIFF
--- a/src/encoding.c
+++ b/src/encoding.c
@@ -15,7 +15,6 @@
  * software. If not, they may be obtained at the above URLs.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
@@ -386,8 +385,13 @@ int encode_string(char *dst, size_t dst_len, argon2_context *ctx,
 #define SX(x)                                                                  \
     do {                                                                       \
         char tmp[30];                                                          \
-        sprintf(tmp, "%lu", (unsigned long)(x));                               \
-        SS(tmp);                                                               \
+        char *p = tmp + sizeof(tmp);                                           \
+        unsigned long v = (x);                                                 \
+        *--p = 0;                                                              \
+        do {                                                                   \
+            *--p = '0' + (v % 10);                                             \
+        } while (v /= 10);                                                     \
+        SS(p);                                                                 \
     } while ((void)0, 0)
 
 #define SB(buf, len)                                                           \


### PR DESCRIPTION
`stdio.h` is only needed for one `sprintf()`, which is only needed to trivially print a non-negative integer. This tiny change keeps all the printf machinery out of static builds.