### PR TITLE
argon2 executable: Add option -b which allows to provide the salt in base64 encoding

### DIFF
--- a/src/encoding.c
+++ b/src/encoding.c
@@ -145,20 +145,7 @@ static size_t to_base64(char *dst, size_t dst_len, const void *src,
     return olen;
 }
 
-/*
- * Decode Base64 chars into bytes. The '*dst_len' value must initially
- * contain the length of the output buffer '*dst'; when the decoding
- * ends, the actual number of decoded bytes is written back in
- * '*dst_len'.
- *
- * Decoding stops when a non-Base64 character is encountered, or when
- * the output buffer capacity is exceeded. If an error occurred (output
- * buffer is too small, invalid last characters leading to unprocessed
- * buffered bits), then NULL is returned; otherwise, the returned value
- * points to the first non-Base64 character in the source stream, which
- * may be the terminating zero.
- */
-static const char *from_base64(void *dst, size_t *dst_len, const char *src) {
+const char *from_base64(void *dst, size_t *dst_len, const char *src) {
     size_t len;
     unsigned char *buf;
     unsigned acc, acc_len;

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -54,4 +54,19 @@ size_t b64len(uint32_t len);
 /* Returns the length of the encoded number num */
 size_t numlen(uint32_t num);
 
+/*
+ * Decode Base64 chars into bytes. The '*dst_len' value must initially
+ * contain the length of the output buffer '*dst'; when the decoding
+ * ends, the actual number of decoded bytes is written back in
+ * '*dst_len'.
+ *
+ * Decoding stops when a non-Base64 character is encountered, or when
+ * the output buffer capacity is exceeded. If an error occurred (output
+ * buffer is too small, invalid last characters leading to unprocessed
+ * buffered bits), then NULL is returned; otherwise, the returned value
+ * points to the first non-Base64 character in the source stream, which
+ * may be the terminating zero.
+ */
+const char *from_base64(void *dst, size_t *dst_len, const char *src);
+
 #endif


### PR DESCRIPTION
Fixes #263.

Rationale:
A Salt in argon2 can be any binary set. Since the command line utility accepts the salt as argument, not all possible characters (for example null-byte) can be passed as salt. With the possibility to specify that the salt is transferred as base64, any binary set can be passed.

Implementation:
- use existing from_base64 function (remove static modifier)
- parameter handling the same as for other parameters