### PR TITLE
Wait for already running threads if a thread creation failed.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -310,7 +310,7 @@ static int fill_memory_blocks_mt(argon2_instance_t *instance) {
 
     for (r = 0; r < instance->passes; ++r) {
         for (s = 0; s < ARGON2_SYNC_POINTS; ++s) {
-            uint32_t l;
+            uint32_t l, ll;
 
             /* 2. Calling threads */
             for (l = 0; l < instance->lanes; ++l) {
@@ -335,6 +335,9 @@ static int fill_memory_blocks_mt(argon2_instance_t *instance) {
                        sizeof(argon2_position_t));
                 if (argon2_thread_create(&thread[l], &fill_segment_thr,
                                          (void *)&thr_data[l])) {
+                    /* Wait for already running threads */
+                    for (ll = 0; ll < l; ++ll)
+                        argon2_thread_join(thread[ll]);
                     rc = ARGON2_THREAD_FAIL;
                     goto fail;
                 }


### PR DESCRIPTION
On memory-constrained systems (like cgroups limited processes)
thread creation often fails.

The code needs to wait for already running threads on error path;
otherwise these threads can access deallocated memory
(and cause a segfault or another crash).