### PR TITLE
Adding new Android binding to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Argon2i 1 iterations  4096 MiB 4 threads:  2.72 cpb 11124.86 Mcycles
 Bindings are available for the following languages (make sure to read
 their documentation):
 
+* [Android (Java/Kotlin)](https://github.com/lambdapioneer/argon2kt) by [@lambdapioneer](https://github.com/lambdapioneer)
 * [Elixir](https://github.com/riverrun/argon2_elixir) by [@riverrun](https://github.com/riverrun)
 * [Erlang](https://github.com/ergenius/eargon2) by [@ergenius](https://github.com/ergenius)
 * [Go](https://github.com/tvdburgt/go-argon2) by [@tvdburgt](https://github.com/tvdburgt)


### PR DESCRIPTION
I've published an Android binding named [Argon2Kt](https://github.com/lambdapioneer/argon2kt) for Argon2 that makes it simple for Android developers to use Argon2. It emerged from a personal mobile app project.

Looking at the existing bindings I've found that the existing Java bindings don't work too well with Android - especially with the now mandatory 64-bit support. Argon2Kt can be used from both Kotlin and Java projects.

I hope adding to the listing will help other mobile developers.