### PR TITLE
Don't fail on existing symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ install: $(RUN) libs
 	$(INSTALL) -d $(INST_LIBRARY)
 	$(INSTALL) -m 0644 $(LIBRARIES) $(INST_LIBRARY)
 ifdef LINKED_LIB_SH
-	cd $(INST_LIBRARY) && ln -s $(notdir $(LIB_SH) $(LINKED_LIB_SH))
+	cd $(INST_LIBRARY) && ln -sf $(notdir $(LIB_SH) $(LINKED_LIB_SH))
 endif
 	$(INSTALL) -d $(INST_BINARY)
 	$(INSTALL) $(RUN) $(INST_BINARY)


### PR DESCRIPTION
When building libargon2 as part a buildsystem like for example buildroot (which targets embedded systems), it shouldn't fail if the symlink is already present on the target rootfs.