### PR TITLE
mingw-w64 / MSYS2 fixes

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -20,14 +20,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <intrin.h>
 #endif
 
 #include "argon2.h"
 
 static uint64_t rdtsc(void) {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return __rdtsc();
 #else
 #if defined(__amd64__) || defined(__x86_64__)

--- a/src/blake2/blake2-impl.h
+++ b/src/blake2/blake2-impl.h
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#if defined(_MSC_VER)
+#ifdef _WIN32
 #define BLAKE2_INLINE __inline
 #elif defined(__GNUC__) || defined(__clang__)
 #define BLAKE2_INLINE __inline__

--- a/src/core.c
+++ b/src/core.c
@@ -16,7 +16,7 @@
  */
 
 /*For memory wiping*/
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <windows.h>
 #include <winbase.h> /* For SecureZeroMemory */
 #endif
@@ -132,7 +132,7 @@ void free_memory(const argon2_context *context, uint8_t *memory,
 #endif
 
 void NOT_OPTIMIZED secure_wipe_memory(void *v, size_t n) {
-#if defined(_MSC_VER) && VC_GE_2005(_MSC_VER)
+#if defined(_MSC_VER) && VC_GE_2005(_MSC_VER) || defined(__MINGW32__)
     SecureZeroMemory(v, n);
 #elif defined memset_s
     memset_s(v, n, 0, n);

--- a/src/genkat.c
+++ b/src/genkat.c
@@ -20,6 +20,12 @@
 #include <string.h>
 #include "argon2.h"
 #include "core.h"
+#ifdef __MINGW32__
+#include <inttypes.h>
+#else
+/* Don't use <inttypes.h> (it's not C89) */
+#define PRIx64 "llx"
+#endif
 
 void initial_kat(const uint8_t *blockhash, const argon2_context *context,
                  argon2_type type) {
@@ -115,7 +121,7 @@ void internal_kat(const argon2_instance_t *instance, uint32_t pass) {
                     : ARGON2_QWORDS_IN_BLOCK;
 
             for (j = 0; j < how_many_words; ++j)
-                printf("Block %.4u [%3u]: %016llx\n", i, j,
+                printf("Block %.4u [%3u]: %016" PRIx64 "\n", i, j,
                        (unsigned long long)instance->memory[i].v[j]);
         }
     }


### PR DESCRIPTION
These are drawn from patches in https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-argon2, with corrections.

`_MSC_VER` is defined specifically by the Microsoft C compiler and should be used for code _specific to that compiler, not Windows_. `_WIN32` is defined by any C compiler targeting Windows *automatically* - i.e. both the Microsoft C compiler and mingw-w64 GCC define it.