### PR TITLE
Do not copy hash on error path.

### DIFF
--- a/src/argon2.c
+++ b/src/argon2.c
@@ -156,11 +156,6 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
         return result;
     }
 
-    /* if raw hash requested, write it */
-    if (hash) {
-        memcpy(hash, out, hashlen);
-    }
-
     /* if encoding requested, write it */
     if (encoded && encodedlen) {
         if (encode_string(encoded, encodedlen, &context, type) != ARGON2_OK) {
@@ -170,6 +165,12 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
             return ARGON2_ENCODING_FAIL;
         }
     }
+
+    /* if raw hash requested, write it */
+    if (hash) {
+        memcpy(hash, out, hashlen);
+    }
+
     clear_internal_memory(out, hashlen);
     free(out);
 


### PR DESCRIPTION
The function argon2_hash can be instructed to copy raw hash and encoding
into pre-allocated memory by the caller.

If encoding fails, the internally used hash storage and the encoding are
cleared in memory. This is true for other error paths as well.

If raw hash is requested and encoding fails, then the internally used
memory containing the hash is cleared, but not the exported one. Since
the function returns an error code, the callers I have examined do not
clear their allocated memory themselves.

The fix for this is simple: Perform encoding before raw hash is copied.
If encoding fails, the encoding error path wins. If it succeeds or was
not requeted, the raw hash export is performed as before.

TLDR: Moved raw hash export behind encoding.