### PR TITLE
Fix OOB write with crazy command line argument.

### DIFF
--- a/src/run.c
+++ b/src/run.c
@@ -91,7 +91,7 @@ Base64-encoded hash string
 @raw_only display only the hexadecimal of the hash
 @version Argon2 version
 */
-static void run(uint32_t outlen, char *pwd, size_t pwdlen, char *salt, uint32_t t_cost,
+static void run(size_t outlen, char *pwd, size_t pwdlen, char *salt, uint32_t t_cost,
                 uint32_t m_cost, uint32_t lanes, uint32_t threads,
                 argon2_type type, int encoded_only, int raw_only, uint32_t version) {
     clock_t start_time, stop_time;
@@ -168,7 +168,7 @@ static void run(uint32_t outlen, char *pwd, size_t pwdlen, char *salt, uint32_t 
 }
 
 int main(int argc, char *argv[]) {
-    uint32_t outlen = OUTLEN_DEF;
+    size_t outlen = OUTLEN_DEF;
     uint32_t m_cost = 1 << LOG_M_COST_DEF;
     uint32_t t_cost = T_COST_DEF;
     uint32_t lanes = LANES_DEF;
@@ -279,6 +279,10 @@ int main(int argc, char *argv[]) {
             if (i < argc - 1) {
                 i++;
                 input = strtoul(argv[i], NULL, 10);
+                if (input == 0 || input == ULONG_MAX ||
+                    input >= SIZE_MAX) {
+                    fatal("bad numeric input for -l");
+                }
                 outlen = input;
                 continue;
             } else {


### PR DESCRIPTION
This only affects:
- argon2 binary
- with crazy command line argument
- on 64 bit systems
- with plenty of RAM

How to reproduce (with a lot of memory and time):
$ echo poc | argon2 12345678 -l 4294967295

The problem is within data type handling in C.

The variable "outlen" is a uint32_t variable. The command line argument
"-l" is converted with strtoul. This by itself means that values larger
than 2**32-1 are truncated on 64 bit systems with an unsigned long being
64 bit, but let's skip this for now.

Later on in run() we see this line:
    out = malloc(outlen + 1);

The variable outlen is a function argument of type uint32_t. If the
variable contains the value 2**32-1, i.e. UINT_MAX, the addition
overflows and leads to 0. Even though malloc takes a size_t, the C
language only performs this integer calculation with 32 bit, unsigned.

Yes, requesting a hash output length of 4 GB is pretty stupid and
your system takes more than that, since base64 encoding and internally
used memory by argon2 library functions will likely lead to an error
sooner or later.

If the code eventually completes, argon2_hash would try to memcpy the
raw hash into the 0-byte allocated memory area. Since the raw hash is
4 GB and not 0, an OOB write and a basically instant crash occur.

Defining outlen as size_t AND validating that the calculation won't
overflow by bailing out early on invalid command line argument fixes the
problem.