### PR TITLE
Validate lanes before memory cost.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -461,6 +461,15 @@ int validate_inputs(const argon2_context *context) {
         }
     }
 
+    /* Validate lanes */
+    if (ARGON2_MIN_LANES > context->lanes) {
+        return ARGON2_LANES_TOO_FEW;
+    }
+
+    if (ARGON2_MAX_LANES < context->lanes) {
+        return ARGON2_LANES_TOO_MANY;
+    }
+
     /* Validate memory cost */
     if (ARGON2_MIN_MEMORY > context->m_cost) {
         return ARGON2_MEMORY_TOO_LITTLE;
@@ -481,15 +490,6 @@ int validate_inputs(const argon2_context *context) {
 
     if (ARGON2_MAX_TIME < context->t_cost) {
         return ARGON2_TIME_TOO_LARGE;
-    }
-
-    /* Validate lanes */
-    if (ARGON2_MIN_LANES > context->lanes) {
-        return ARGON2_LANES_TOO_FEW;
-    }
-
-    if (ARGON2_MAX_LANES < context->lanes) {
-        return ARGON2_LANES_TOO_MANY;
     }
 
     /* Validate threads */


### PR DESCRIPTION
The validation of memory cost uses a multiple of the amount of lanes.
It would be an unsigned overflow, therefore not critical, especially
since the lane validation would bail out anyway.

But an invalid lane amount would lead to the error return value
ARGON2_MEMORY_TOO_LITTLE which is not exactly what went wrong.

Therefore bail out with more specific error return value.