### PR TITLE
Fix comment in code shown in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ int main(void)
     uint8_t *pwd = (uint8_t *)strdup(PWD);
     uint32_t pwdlen = strlen((char *)pwd);
 
-    uint32_t t_cost = 2;            // 1-pass computation
+    uint32_t t_cost = 2;            // 2-pass computation
     uint32_t m_cost = (1<<16);      // 64 mebibytes memory usage
     uint32_t parallelism = 1;       // number of threads and lanes
 


### PR DESCRIPTION
I was a tad confused while looking through the readme, since the example shows setting the variable to `2` for a `1-pass computation`. I believe this makes it correct.