### PR TITLE
Add dargon2 (Dart) bindings to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Bindings are available for the following languages (make sure to read
 their documentation):
 
 * [Android (Java/Kotlin)](https://github.com/lambdapioneer/argon2kt) by [@lambdapioneer](https://github.com/lambdapioneer)
+* [Dart](https://github.com/tmthecoder/dargon2) by [@tmthecoder](https://github.com/tmthecoder)
 * [Elixir](https://github.com/riverrun/argon2_elixir) by [@riverrun](https://github.com/riverrun)
 * [Erlang](https://github.com/ergenius/eargon2) by [@ergenius](https://github.com/ergenius)
 * [Go](https://github.com/tvdburgt/go-argon2) by [@tvdburgt](https://github.com/tvdburgt)


### PR DESCRIPTION
Hello! I recently created the Dart bindings for Argon2: [dargon2](https://github.com/tmthecoder/dargon2). It is also published to Dart [pub.dev](https://pub.dev/packages/dargon2). Would you be able to merge the request to add it to the README?

Thank you! 