### PR TITLE
Don't use @rpath on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),DragonFly FreeBSD NetBSD OpenBSD))
 endif
 ifeq ($(KERNEL_NAME), Darwin)
 	LIB_EXT := $(ABI_VERSION).dylib
-	LIB_CFLAGS := -dynamiclib -install_name @rpath/lib$(LIB_NAME).$(LIB_EXT)
+	LIB_CFLAGS = -dynamiclib -install_name $(PREFIX)/$(LIBRARY_REL)/lib$(LIB_NAME).$(LIB_EXT)
 	LINKED_LIB_EXT := dylib
 	PC_EXTRA_LIBS ?=
 endif

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ Please report bugs as issues on this repository.
 ## Usage
 
 `make` builds the executable `argon2`, the static library `libargon2.a`,
-and the shared library `libargon2.so` (or `libargon2.dylib` on OSX).
-Make sure to run `make test` to verify that your build produces valid
-results. `make install PREFIX=/usr` installs it to your system.
+and the shared library `libargon2.so` (or on macOS, the dynamic library
+`libargon2.dylib` -- make sure to specify the installation prefix when
+you compile: `make PREFIX=/usr`). Make sure to run `make test` to verify
+that your build produces valid results. `sudo make install PREFIX=/usr`
+installs it to your system.
 
 ### Command-line utility
 


### PR DESCRIPTION
There's no particular benefit to using `@rpath` instead of just using the absolute path like everybody else does, so just do that.

Late assignment (`=`) is used instead of immediate assignment (`:=`) because `LIBRARY_REL` isn't defined until later in the Makefile.

The user will need to specify `PREFIX` when running `make` in addition to when running `make install`. The readme is updated to reflect that.