### PR TITLE
Feature/swift package manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "argon2",
+    products: [
+        .library(
+            name: "argon2",
+            targets: ["argon2"]),
+    ],
+    targets: [
+        .target(
+            name: "argon2",
+            path: ".",
+            exclude: [
+                "kats",
+                "vs2015",
+                "latex",
+                "libargon2.pc.in",
+                "export.sh",
+                "appveyor.yml",
+                "Argon2.sln",
+                "argon2-specs.pdf",
+                "CHANGELOG.md",
+                "LICENSE",
+                "Makefile",
+                "man",
+                "README.md",
+                "src/bench.c",
+                "src/genkat.c",
+                "src/opt.c",
+                "src/run.c",
+                "src/test.c",
+            ],
+            sources: [
+                "src/blake2/blake2b.c",
+                "src/argon2.c",
+                "src/core.c",
+                "src/encoding.c",
+                "src/ref.c",
+                "src/thread.c"
+            ]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ their documentation):
 * [Perl](https://github.com/Leont/crypt-argon2) by [@leont](https://github.com/Leont)
 * [mruby](https://github.com/Asmod4n/mruby-argon2) by [@Asmod4n](https://github.com/Asmod4n)
 * [Swift](https://github.com/ImKcat/CatCrypto) by [@ImKcat](https://github.com/ImKcat)
+* [Swift](https://github.com/tmthecoder/Argon2Swift) by [@tmthecoder](https://github.com/tmthecoder)
 
 
 ## Test suite


### PR DESCRIPTION
Allows Swift Package Manager users to easily add argon2 as a dependency. Simply add:

`.package(name: "argon2", url: "https://github.com/P-H-C/phc-winner-argon2.git", .branch("master"))`

to your dependencies after this PR is merged (substitute `.branch("master")` as needed to pin to a versioned release)