### PR TITLE
Update README link to argon2rs (Rust binding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ their documentation):
 * [Python (ffi, with keyed hashing)](https://github.com/ultrahorizon/pyargon2), by [@ultrahorizon](https://github.com/ultrahorizon)
 * [R](https://cran.r-project.org/package=argon2) by [@wrathematics](https://github.com/wrathematics)
 * [Ruby](https://github.com/technion/ruby-argon2) by [@technion](https://github.com/technion)
-* [Rust](https://github.com/quininer/argon2-rs) by [@quininer](https://github.com/quininer)
+* [Rust](https://github.com/bryant/argon2rs) by [@bryant](https://github.com/bryant)
 * [Rust](https://docs.rs/argonautica/) by [@bcmyers](https://github.com/bcmyers/)
 * [C#/.NET CoreCLR](https://github.com/kmaragon/Konscious.Security.Cryptography) by [@kmaragon](https://github.com/kmaragon)
 * [Perl](https://github.com/Leont/crypt-argon2) by [@leont](https://github.com/Leont)


### PR DESCRIPTION
Per the README in [quininer/argon2-rs](https://github.com/quininer/argon2-rs), it has been superseded by [bryant/argon2rs](https://github.com/bryant/argon2rs) which is written purely using Rust.