### PR TITLE
Rudimentary support for midipix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,12 @@ ifeq ($(findstring MSYS, $(KERNEL_NAME)), MSYS)
 	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
 	PC_EXTRA_LIBS ?=
 endif
+ifeq ($(KERNEL_NAME), midipix)
+	LIB_EXT := so.$(ABI_VERSION)
+	LIB_CFLAGS := -shared -fPIC -fvisibility=hidden -DA2_VISCTL=1 -Wl,--out-dsolib,lib$(LIB_NAME).lib.a
+	SO_LDFLAGS := -Wl,-soname,lib$(LIB_NAME).$(LIB_EXT)
+	LINKED_LIB_EXT := so
+endif
 ifeq ($(KERNEL_NAME), SunOS)
 	CC := gcc
 	CFLAGS += -D_REENTRANT

--- a/src/core.c
+++ b/src/core.c
@@ -125,6 +125,8 @@ void free_memory(const argon2_context *context, uint8_t *memory,
 
 #if defined(__OpenBSD__)
 #define HAVE_EXPLICIT_BZERO 1
+#elif defined(__midipix__)
+#define HAVE_EXPLICIT_BZERO 1
 #elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2,25)
 #define HAVE_EXPLICIT_BZERO 1


### PR DESCRIPTION
Midipix is a POSIX layer for microsoft windows, like cygwin.