### PR TITLE
Don't call _endthreadex/pthread_exit

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -284,7 +284,6 @@ static void *fill_segment_thr(void *thread_data)
 {
     argon2_thread_data *my_data = thread_data;
     fill_segment(my_data->instance_ptr, my_data->pos);
-    argon2_thread_exit();
     return 0;
 }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -46,12 +46,4 @@ int argon2_thread_join(argon2_thread_handle_t handle) {
 #endif
 }
 
-void argon2_thread_exit(void) {
-#if defined(_WIN32)
-    _endthreadex(0);
-#else
-    pthread_exit(NULL);
-#endif
-}
-
 #endif /* ARGON2_NO_THREADS */

--- a/src/thread.h
+++ b/src/thread.h
@@ -58,10 +58,5 @@ int argon2_thread_create(argon2_thread_handle_t *handle,
 */
 int argon2_thread_join(argon2_thread_handle_t handle);
 
-/* Terminate the current thread. Must be run inside a thread created by
- * argon2_thread_create.
-*/
-void argon2_thread_exit(void);
-
 #endif /* ARGON2_NO_THREADS */
 #endif


### PR DESCRIPTION
Returning from the thread creation function is documented to be a valid
way of exiting a thread on both Windows and pthread systems. Removing
the explicit call avoids the need to install libgcc_s.so in initramfs
for glibc systems, and slightly reduces code size.