### PR TITLE
Add dargon2_flutter for Flutter projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ Bindings are available for the following languages (make sure to read
 their documentation):
 
 * [Android (Java/Kotlin)](https://github.com/lambdapioneer/argon2kt) by [@lambdapioneer](https://github.com/lambdapioneer)
-* [Dart](https://github.com/tmthecoder/dargon2) by [@tmthecoder](https://github.com/tmthecoder)
+* [Dart (Native)](https://github.com/tmthecoder/dargon2) by [@tmthecoder](https://github.com/tmthecoder)
+* [Dart (Flutter)](https://github.com/tmthecoder/dargon2_flutter) by [@tmthecoder](https://github.com/tmthecoder)
 * [Elixir](https://github.com/riverrun/argon2_elixir) by [@riverrun](https://github.com/riverrun)
 * [Erlang](https://github.com/ergenius/eargon2) by [@ergenius](https://github.com/ergenius)
 * [Go](https://github.com/tvdburgt/go-argon2) by [@tvdburgt](https://github.com/tvdburgt)

--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ Bindings are available for the following languages (make sure to read
 their documentation):
 
 * [Android (Java/Kotlin)](https://github.com/lambdapioneer/argon2kt) by [@lambdapioneer](https://github.com/lambdapioneer)
-* [Dart (Native)](https://github.com/tmthecoder/dargon2) by [@tmthecoder](https://github.com/tmthecoder)
-* [Dart (Flutter)](https://github.com/tmthecoder/dargon2_flutter) by [@tmthecoder](https://github.com/tmthecoder)
+* [Dart (Native)](https://github.com/tmthecoder/dargon2/blob/main/dargon2) by [@tmthecoder](https://github.com/tmthecoder)
+* [Dart (Flutter)](https://github.com/tmthecoder/dargon2_flutter/blob/main/dargon2_flutter) by [@tmthecoder](https://github.com/tmthecoder)
 * [Elixir](https://github.com/riverrun/argon2_elixir) by [@riverrun](https://github.com/riverrun)
 * [Erlang](https://github.com/ergenius/eargon2) by [@ergenius](https://github.com/ergenius)
 * [Go](https://github.com/tvdburgt/go-argon2) by [@tvdburgt](https://github.com/tvdburgt)


### PR DESCRIPTION
Adds in the reference for Flutter projects, [dargon2_flutter], which differs slightly from [dargon2], which provides argon2 functionality in Dart for native devices only. 

The Flutter plugin is necessary in providing bindings for mobile & web devices which require a different method of loading the argon2 reference library.

This PR adds in the reference to the flutter plugin in the readme and clarifies the distinction between [dargon2] and [dargon2_flutter].

Let me know if I need to make any clarifications!

[dargon2]: https://github.com/tmthecoder/dargon2/blob/main/dargon2
[dargon2_flutter]: https://github.com/tmthecoder/dargon2/blob/main/dargon2_flutter