### PR TITLE
Allow argon2_context to accept pointers to const buffers

### DIFF
--- a/include/argon2.h
+++ b/include/argon2.h
@@ -192,17 +192,17 @@ typedef struct Argon2_Context {
     uint8_t *out;    /* output array */
     uint32_t outlen; /* digest length */
 
-    uint8_t *pwd;    /* password array */
-    uint32_t pwdlen; /* password length */
+    uint8_t const *pwd; /* password array */
+    uint32_t pwdlen;    /* password length */
 
-    uint8_t *salt;    /* salt array */
-    uint32_t saltlen; /* salt length */
+    uint8_t const *salt; /* salt array */
+    uint32_t saltlen;    /* salt length */
 
-    uint8_t *secret;    /* key array */
-    uint32_t secretlen; /* key length */
+    uint8_t const *secret; /* key array */
+    uint32_t secretlen;    /* key length */
 
-    uint8_t *ad;    /* associated data array */
-    uint32_t adlen; /* associated data length */
+    uint8_t const *ad; /* associated data array */
+    uint32_t adlen;    /* associated data length */
 
     uint32_t t_cost;  /* number of passes */
     uint32_t m_cost;  /* amount of memory requested (KB) */


### PR DESCRIPTION
Accepting pointers to non-const `uint8_t` buffers means const buffers have to have their constness cast away before passing to this structure.  Argon2 doesn't modify any of these buffers except the output array `out`, so the rest should be pointers to const buffers.