### PR TITLE
Added explicit casts to malloc usages in order to fix compilation on C++

### DIFF
--- a/cpp.patch
+++ b/cpp.patch
@@ -1,0 +1,71 @@
+diff --git a/src/argon2.c b/src/argon2.c
+index 34da3d6..ae3abc7 100644
+--- a/src/argon2.c
++++ b/src/argon2.c
+@@ -124,7 +124,7 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
+         return ARGON2_OUTPUT_TOO_SHORT;
+     }
+ 
+-    out = malloc(hashlen);
++    out = (uint8_t *)malloc(hashlen);
+     if (!out) {
+         return ARGON2_MEMORY_ALLOCATION_ERROR;
+     }
+@@ -276,8 +276,8 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
+     ctx.saltlen = max_field_len;
+     ctx.outlen = max_field_len;
+ 
+-    ctx.salt = malloc(ctx.saltlen);
+-    ctx.out = malloc(ctx.outlen);
++    ctx.salt = (uint8_t *)malloc(ctx.saltlen);
++    ctx.out = (uint8_t *)malloc(ctx.outlen);
+     if (!ctx.salt || !ctx.out) {
+         ret = ARGON2_MEMORY_ALLOCATION_ERROR;
+         goto fail;
+@@ -293,7 +293,7 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
+ 
+     /* Set aside the desired result, and get a new buffer. */
+     desired_result = ctx.out;
+-    ctx.out = malloc(ctx.outlen);
++    ctx.out = (uint8_t *)malloc(ctx.outlen);
+     if (!ctx.out) {
+         ret = ARGON2_MEMORY_ALLOCATION_ERROR;
+         goto fail;
+diff --git a/src/core.c b/src/core.c
+index e697882..0d0a464 100644
+--- a/src/core.c
++++ b/src/core.c
+@@ -102,7 +102,7 @@ int allocate_memory(const argon2_context *context, uint8_t **memory,
+     if (context->allocate_cbk) {
+         (context->allocate_cbk)(memory, memory_size);
+     } else {
+-        *memory = malloc(memory_size);
++        *memory = (uint8_t *)malloc(memory_size);
+     }
+ 
+     if (*memory == NULL) {
+@@ -282,7 +282,7 @@ static unsigned __stdcall fill_segment_thr(void *thread_data)
+ static void *fill_segment_thr(void *thread_data)
+ #endif
+ {
+-    argon2_thread_data *my_data = thread_data;
++    argon2_thread_data *my_data = (argon2_thread_data *)thread_data;
+     fill_segment(my_data->instance_ptr, my_data->pos);
+     argon2_thread_exit();
+     return 0;
+@@ -296,13 +296,13 @@ static int fill_memory_blocks_mt(argon2_instance_t *instance) {
+     int rc = ARGON2_OK;
+ 
+     /* 1. Allocating space for threads */
+-    thread = calloc(instance->lanes, sizeof(argon2_thread_handle_t));
++    thread = (argon2_thread_handle_t *)calloc(instance->lanes, sizeof(argon2_thread_handle_t));
+     if (thread == NULL) {
+         rc = ARGON2_MEMORY_ALLOCATION_ERROR;
+         goto fail;
+     }
+ 
+-    thr_data = calloc(instance->lanes, sizeof(argon2_thread_data));
++    thr_data = (argon2_thread_data *)calloc(instance->lanes, sizeof(argon2_thread_data));
+     if (thr_data == NULL) {
+         rc = ARGON2_MEMORY_ALLOCATION_ERROR;
+         goto fail;

--- a/src/argon2.c
+++ b/src/argon2.c
@@ -124,7 +124,7 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
         return ARGON2_OUTPUT_TOO_SHORT;
     }
 
-    out = malloc(hashlen);
+    out = (uint8_t *)malloc(hashlen);
     if (!out) {
         return ARGON2_MEMORY_ALLOCATION_ERROR;
     }
@@ -276,8 +276,8 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     ctx.saltlen = max_field_len;
     ctx.outlen = max_field_len;
 
-    ctx.salt = malloc(ctx.saltlen);
-    ctx.out = malloc(ctx.outlen);
+    ctx.salt = (uint8_t *)malloc(ctx.saltlen);
+    ctx.out = (uint8_t *)malloc(ctx.outlen);
     if (!ctx.salt || !ctx.out) {
         ret = ARGON2_MEMORY_ALLOCATION_ERROR;
         goto fail;
@@ -293,7 +293,7 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
 
     /* Set aside the desired result, and get a new buffer. */
     desired_result = ctx.out;
-    ctx.out = malloc(ctx.outlen);
+    ctx.out = (uint8_t *)malloc(ctx.outlen);
     if (!ctx.out) {
         ret = ARGON2_MEMORY_ALLOCATION_ERROR;
         goto fail;

--- a/src/core.c
+++ b/src/core.c
@@ -102,7 +102,7 @@ int allocate_memory(const argon2_context *context, uint8_t **memory,
     if (context->allocate_cbk) {
         (context->allocate_cbk)(memory, memory_size);
     } else {
-        *memory = malloc(memory_size);
+        *memory = (uint8_t *)malloc(memory_size);
     }
 
     if (*memory == NULL) {
@@ -282,7 +282,7 @@ static unsigned __stdcall fill_segment_thr(void *thread_data)
 static void *fill_segment_thr(void *thread_data)
 #endif
 {
-    argon2_thread_data *my_data = thread_data;
+    argon2_thread_data *my_data = (argon2_thread_data *)thread_data;
     fill_segment(my_data->instance_ptr, my_data->pos);
     argon2_thread_exit();
     return 0;
@@ -296,13 +296,13 @@ static int fill_memory_blocks_mt(argon2_instance_t *instance) {
     int rc = ARGON2_OK;
 
     /* 1. Allocating space for threads */
-    thread = calloc(instance->lanes, sizeof(argon2_thread_handle_t));
+    thread = (argon2_thread_handle_t *)calloc(instance->lanes, sizeof(argon2_thread_handle_t));
     if (thread == NULL) {
         rc = ARGON2_MEMORY_ALLOCATION_ERROR;
         goto fail;
     }
 
-    thr_data = calloc(instance->lanes, sizeof(argon2_thread_data));
+    thr_data = (argon2_thread_data *)calloc(instance->lanes, sizeof(argon2_thread_data));
     if (thr_data == NULL) {
         rc = ARGON2_MEMORY_ALLOCATION_ERROR;
         goto fail;


### PR DESCRIPTION
When compiling this Argon2 lib in a C++ project, the compilation fails due to illegal conversions from `void*` (what `malloc(size_t)` returns) to `uint8_t*` - this is perfectly valid in C (and don't get me wrong, I love C just as much as everyone else) but it's a non-ignorable error in C++.

Since you put

```C
#if defined(__cplusplus)
extern "C" {
#endif
```

inside `argon2.h` I thought I'd open this pull request, because it makes no sense to hint C++ friendliness with that `extern "C"` if compilation then fails in C++ due to implicit pointer type conversions.

My idea here would be to

* Either accept this pull request and merge full C++ compatibility into Argon2 lib with minimal changes
* Or reject this pull request but then also remove the `#ifdef _cplusplus` block at the top of the header file to avoid confusion for C++ devs interested in using this library

Kindest regards, and have a happy and successful new year! :D