### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ you compile: `make PREFIX=/usr`). Make sure to run `make test` to verify
 that your build produces valid results. `sudo make install PREFIX=/usr`
 installs it to your system.
 
+### Installing from vcpkg
+
+You can download and install `argon2` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+  git clone https://github.com/Microsoft/vcpkg.git
+  cd vcpkg
+  ./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+  ./vcpkg integrate install
+  ./vcpkg install argon2
+```
+
+The `argon2` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Command-line utility
 
 `argon2` is a command-line utility to test specific Argon2 instances


### PR DESCRIPTION
`argon2` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `argon2` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `argon2`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/argon2/portfile.cmake). We try to keep the library maintained as close as possible to the original library.