### PR TITLE
Expose encode_string and decode_string as part of the public API.

### DIFF
--- a/include/argon2.h
+++ b/include/argon2.h
@@ -416,6 +416,32 @@ ARGON2_PUBLIC int argon2_verify_ctx(argon2_context *context, const char *hash,
  */
 ARGON2_PUBLIC const char *argon2_error_message(int error_code);
 
+/*
+* Encodes an Argon2 hash string into the provided buffer. 'dst_len'
+* contains the size, in characters, of the 'dst' buffer; if 'dst_len'
+* is less than the number of required characters (including the
+* terminating 0), then this function returns ARGON2_ENCODING_ERROR.
+*
+* on success, ARGON2_OK is returned.
+*/
+int argon2_encode_string(char *dst, size_t dst_len, argon2_context *ctx,
+                  argon2_type type);
+
+/*
+* Decodes an Argon2 hash string into the provided structure 'ctx'.
+* The only fields that must be set prior to this call are ctx.saltlen and
+* ctx.outlen (which must be the maximal salt and out length values that are
+* allowed), ctx.salt and ctx.out (which must be buffers of the specified
+* length), and ctx.pwd and ctx.pwdlen which must hold a valid password.
+*
+* Invalid input string causes an error. On success, the ctx is valid and all
+* fields have been initialized.
+*
+* Returned value is ARGON2_OK on success, other ARGON2_ codes on error.
+*/
+int argon2_decode_string(argon2_context *ctx, const char *str, argon2_type type);
+
+
 /**
  * Returns the encoded hash length for the given input parameters
  * @param t_cost  Number of iterations

--- a/src/argon2.c
+++ b/src/argon2.c
@@ -163,7 +163,7 @@ int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
 
     /* if encoding requested, write it */
     if (encoded && encodedlen) {
-        if (encode_string(encoded, encodedlen, &context, type) != ARGON2_OK) {
+        if (argon2_encode_string(encoded, encodedlen, &context, type) != ARGON2_OK) {
             clear_internal_memory(out, hashlen); /* wipe buffers if error */
             clear_internal_memory(encoded, encodedlen);
             free(out);
@@ -286,7 +286,7 @@ int argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     ctx.pwd = (uint8_t *)pwd;
     ctx.pwdlen = (uint32_t)pwdlen;
 
-    ret = decode_string(&ctx, encoded, type);
+    ret = argon2_decode_string(&ctx, encoded, type);
     if (ret != ARGON2_OK) {
         goto fail;
     }

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -252,10 +252,10 @@ static const char *decode_decimal(const char *str, unsigned long *v) {
  * output length must be in the allowed ranges defined in argon2.h.
  *
  * The ctx struct must contain buffers large enough to hold the salt and pwd
- * when it is fed into decode_string.
+ * when it is fed into argon2_decode_string.
  */
 
-int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
+int argon2_decode_string(argon2_context *ctx, const char *str, argon2_type type) {
 
 /* check for prefix */
 #define CC(prefix)                                                             \
@@ -370,7 +370,7 @@ int decode_string(argon2_context *ctx, const char *str, argon2_type type) {
 #undef BIN
 }
 
-int encode_string(char *dst, size_t dst_len, argon2_context *ctx,
+int argon2_encode_string(char *dst, size_t dst_len, argon2_context *ctx,
                   argon2_type type) {
 #define SS(str)                                                                \
     do {                                                                       \

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -23,31 +23,6 @@
 #define ARGON2_MIN_DECODED_SALT_LEN UINT32_C(8)
 #define ARGON2_MIN_DECODED_OUT_LEN UINT32_C(12)
 
-/*
-* encode an Argon2 hash string into the provided buffer. 'dst_len'
-* contains the size, in characters, of the 'dst' buffer; if 'dst_len'
-* is less than the number of required characters (including the
-* terminating 0), then this function returns ARGON2_ENCODING_ERROR.
-*
-* on success, ARGON2_OK is returned.
-*/
-int encode_string(char *dst, size_t dst_len, argon2_context *ctx,
-                  argon2_type type);
-
-/*
-* Decodes an Argon2 hash string into the provided structure 'ctx'.
-* The only fields that must be set prior to this call are ctx.saltlen and
-* ctx.outlen (which must be the maximal salt and out length values that are
-* allowed), ctx.salt and ctx.out (which must be buffers of the specified
-* length), and ctx.pwd and ctx.pwdlen which must hold a valid password.
-*
-* Invalid input string causes an error. On success, the ctx is valid and all
-* fields have been initialized.
-*
-* Returned value is ARGON2_OK on success, other ARGON2_ codes on error.
-*/
-int decode_string(argon2_context *ctx, const char *str, argon2_type type);
-
 /* Returns the length of the encoded byte stream with length len */
 size_t b64len(uint32_t len);
 


### PR DESCRIPTION
My use case for this is that having access to `argon2_decode_string` allows us to check the settings that a password was hashed with comply with the current security configuration and opportunistically rehash passwords that do not match the current security configuration.