### PR TITLE
fix: Use correct include directory for compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Here the time cost `t_cost` is set to 2 iterations, the
 memory cost `m_cost` is set to 2<sup>16</sup> kibibytes (64 mebibytes),
 and parallelism is set to 1 (single-thread).
 
-Compile for example as `gcc test.c libargon2.a -Isrc -o test`, if the program
+Compile for example as `gcc test.c libargon2.a -Iinclude -o test`, if the program
 below is named `test.c` and placed in the project's root directory.
 
 ```c


### PR DESCRIPTION
The GCC command provided suggests using `src` as the include path. When I tried to compile using this, it could not find the header file `argon2.h`. Changing it to `include` fixes the problem and the test program compiles properly.